### PR TITLE
start moving TODO tasks to issues

### DIFF
--- a/README.github-conventions.md
+++ b/README.github-conventions.md
@@ -1,0 +1,27 @@
+## GitHub Issue Organization Guidelines
+
+To approximate Agile hierarchy (epic > feature > story) in GitHub Issues:
+
+- **Labels**  
+  Tag issues with labels such as `epic`, `feature`, or `story` to indicate their role in the hierarchy. Use additional labels for type (bug, enhancement), component (frontend, backend), and status (todo, in progress, review).
+
+- **Milestones**  
+  Group issues using milestones based on delivery goals (e.g., release, sprint). You can use milestones for broader time-based groupings and epics as labels, or designate major initiatives as milestones.
+
+- **Issue Linking**  
+  Create an "epic" issue and reference related "feature" or "story" issues within its description using task lists or markdown links:
+
+  ```
+  - [ ] #123 Add login functionality
+  - [ ] #124 Build logout process
+  ```
+
+  This enables quick navigation and clear relationships between items.
+
+- **Templates and Conventions**  
+  Maintain consistent label naming conventions and consider issue templates for each hierarchy layer to ensure clarity and completeness.
+
+- **Triaging and Assignment**  
+  Regularly review unassigned issues, triage, and assign owners to encourage accountability and avoid backlog clutter.
+
+For more advanced hierarchy and backlog management, consider using GitHub Projects Beta or tools like Zenhub for native epic/story relationships.

--- a/docs/testing-improvements.plan.md
+++ b/docs/testing-improvements.plan.md
@@ -241,7 +241,7 @@ Below is a plan to improve test quality, consistency, and alignment with React 1
   with clear unit-test assertions.
 - `AddPetPage` submit/cancel/dirty flows using user-event and dialog assertions.
 
-4. Expand coverage on cross-cutting concerns
+4. [In GitHub] Expand coverage on cross-cutting concerns
 
 - Routing: unauthenticated redirects, 404 route, `authEnabled=false` behavior.
 - i18n: one per-namespace sanity test in `en` and one alternate locale using `withLocale`.
@@ -271,9 +271,9 @@ Below is a plan to improve test quality, consistency, and alignment with React 1
   remove snapshots, and update queries in the files listed above.
 - [:white_check_mark:] Introduce `testUtils/factories` and `mockZustand` helpers; refactor `PetList` and `AddPetPage`
   tests to use them.
-- Restore the skipped/commented tests for the add and cancel flows with robust, user-centric interactions.
+- [:white_check_mark:] Restore the skipped/commented tests for the add and cancel flows with robust, user-centric interactions.
 - Add routing edge tests and one focused a11y test for the confirm dialog.
-- Add testing ESLint plugins and, if desired, a coverage threshold in Vitest config.
+- [:white_check_mark:] Add testing ESLint plugins and, if desired, a coverage threshold in Vitest config.
 
 If you’d like, I can start by refactoring one target file (e.g., `AddPetPage.test.tsx`) to demonstrate the updated
 patterns, then proceed feature-by-feature.


### PR DESCRIPTION
Starting moving TODO items from markdown files to GitHub issues. This PR is related to items from testing-improvements.plan.md. Items moved to issues are marked with ✅ 

This work is related to #13 but does not complete that work.