### PR TITLE
chore: move build + test:coverage to pre-push (lighten pre-commit)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
 pnpm run format
 git add .
 npx lint-staged
-pnpm run build
-pnpm run test:coverage

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+pnpm run build
+pnpm run test:coverage


### PR DESCRIPTION
## Summary

Pre-commit currently runs `format → lint-staged → build → test:coverage` — about 30s–2min on every commit. That actively trains the `--no-verify` habit and pushes people toward fewer/larger commits to amortize the wait.

This PR keeps the same correctness guarantees pre-merge but moves the slow steps to `pre-push`:

**Before**
- `pre-commit`: format, lint-staged, build, test:coverage  ← 30s-2min
- `pre-push`: (none)

**After**
- `pre-commit`: format, lint-staged  ← <5s typically
- `pre-push`: build, test:coverage  ← unchanged total wall time, but per-`git push` instead of per-`git commit`

CI still runs the full pipeline on PR open/synchronize, so nothing about the merge bar changes.

Tier 2 item #5 from the eng review plan.

## Test plan

- [x] Pre-commit on this branch ran fast (just format + lint-staged)
- [x] Pre-push on this branch ran build + test:coverage, both green
- [x] `.husky/pre-push` is executable (mode 755)
- [ ] CI green on this PR