### PR TITLE
refactor: route useMedicationStore through medicationService

### DIFF
--- a/src/services/medicationService.test.ts
+++ b/src/services/medicationService.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MedicationService } from './medicationService';
+import { MedicationRepository } from '@repositories/MedicationRepository';
+
+vi.mock('@repositories/MedicationRepository');
+
+describe('MedicationService', () => {
+  let service: MedicationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new MedicationService();
+  });
+
+  it('getMedications instantiates repo and calls getActiveList', async () => {
+    const options = { orderBy: 'name' as const };
+    const mockGetActiveList = vi.fn().mockResolvedValue([]);
+    vi.mocked(MedicationRepository).mockImplementation(
+      () =>
+        ({
+          getActiveList: mockGetActiveList,
+        }) as unknown as MedicationRepository
+    );
+
+    await service.getMedications(options);
+
+    expect(MedicationRepository).toHaveBeenCalledWith();
+    expect(mockGetActiveList).toHaveBeenCalledWith(options);
+  });
+
+  it('addMedication instantiates repo and calls createMedication', async () => {
+    const input = {
+      name: 'Aspirin',
+      defaultForm: 'pill' as const,
+      defaultRoute: 'oral' as const,
+      isArchived: false,
+      createdBy: 'user-1',
+    };
+    const mockCreate = vi.fn().mockResolvedValue({ id: '1', ...input });
+    vi.mocked(MedicationRepository).mockImplementation(
+      () =>
+        ({
+          createMedication: mockCreate,
+        }) as unknown as MedicationRepository
+    );
+
+    await service.addMedication(input);
+
+    expect(MedicationRepository).toHaveBeenCalledWith();
+    expect(mockCreate).toHaveBeenCalledWith(input);
+  });
+
+  it('updateMedication instantiates repo and calls updateMedication', async () => {
+    const id = 'med1';
+    const updates = { name: 'Aspirin Updated' };
+    const mockUpdate = vi.fn().mockResolvedValue({ id, ...updates });
+    vi.mocked(MedicationRepository).mockImplementation(
+      () =>
+        ({
+          updateMedication: mockUpdate,
+        }) as unknown as MedicationRepository
+    );
+
+    await service.updateMedication(id, updates);
+
+    expect(MedicationRepository).toHaveBeenCalledWith();
+    expect(mockUpdate).toHaveBeenCalledWith(id, updates);
+  });
+
+  it('archiveMedication instantiates repo and calls archive', async () => {
+    const id = 'med1';
+    const mockArchive = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(MedicationRepository).mockImplementation(
+      () =>
+        ({
+          archive: mockArchive,
+        }) as unknown as MedicationRepository
+    );
+
+    await service.archiveMedication(id);
+
+    expect(MedicationRepository).toHaveBeenCalledWith();
+    expect(mockArchive).toHaveBeenCalledWith(id);
+  });
+});

--- a/src/services/medicationService.ts
+++ b/src/services/medicationService.ts
@@ -1,0 +1,38 @@
+import { MedicationRepository } from '@repositories/MedicationRepository';
+import type {
+  MedicationDefinition,
+  MedicationDefinitionCreateInput,
+  MedicationDefinitionUpdateInput,
+} from '@features/medications/types';
+import type { QueryOptions } from '@repositories/types';
+
+export class MedicationService {
+  async getMedications(
+    options?: QueryOptions
+  ): Promise<MedicationDefinition[]> {
+    const repo = new MedicationRepository();
+    return repo.getActiveList(options);
+  }
+
+  async addMedication(
+    input: MedicationDefinitionCreateInput
+  ): Promise<MedicationDefinition> {
+    const repo = new MedicationRepository();
+    return repo.createMedication(input);
+  }
+
+  async updateMedication(
+    id: string,
+    updates: MedicationDefinitionUpdateInput
+  ): Promise<MedicationDefinition> {
+    const repo = new MedicationRepository();
+    return repo.updateMedication(id, updates);
+  }
+
+  async archiveMedication(id: string): Promise<void> {
+    const repo = new MedicationRepository();
+    await repo.archive(id);
+  }
+}
+
+export const medicationService = new MedicationService();

--- a/src/store/useMedicationStore.test.ts
+++ b/src/store/useMedicationStore.test.ts
@@ -1,11 +1,17 @@
-import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useMedicationStore } from './useMedicationStore';
-import { MedicationRepository } from '@repositories/MedicationRepository';
+import { medicationService } from '@services/medicationService';
 import type { MedicationDefinition } from '@features/medications/types';
 
-// Mock Repository
-vi.mock('@repositories/MedicationRepository');
+vi.mock('@services/medicationService', () => ({
+  medicationService: {
+    getMedications: vi.fn(),
+    addMedication: vi.fn(),
+    updateMedication: vi.fn(),
+    archiveMedication: vi.fn(),
+  },
+}));
 
 describe('useMedicationStore', () => {
   beforeEach(() => {
@@ -22,8 +28,8 @@ describe('useMedicationStore', () => {
       { id: '1', name: 'Aspirin' },
       { id: '2', name: 'Benadryl' },
     ];
-    (MedicationRepository.prototype.getActiveList as Mock).mockResolvedValue(
-      mockMeds
+    vi.mocked(medicationService.getMedications).mockResolvedValue(
+      mockMeds as MedicationDefinition[]
     );
 
     const { result } = renderHook(() => useMedicationStore());
@@ -32,6 +38,9 @@ describe('useMedicationStore', () => {
       await result.current.fetchMedications();
     });
 
+    expect(medicationService.getMedications).toHaveBeenCalledWith({
+      orderBy: 'name',
+    });
     expect(result.current.medications).toEqual(mockMeds);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
@@ -39,8 +48,8 @@ describe('useMedicationStore', () => {
 
   it('should add a medication', async () => {
     const newMed = { id: '3', name: 'Claritin' };
-    (MedicationRepository.prototype.createMedication as Mock).mockResolvedValue(
-      newMed
+    vi.mocked(medicationService.addMedication).mockResolvedValue(
+      newMed as MedicationDefinition
     );
 
     const { result } = renderHook(() => useMedicationStore());
@@ -55,11 +64,12 @@ describe('useMedicationStore', () => {
       });
     });
 
+    expect(medicationService.addMedication).toHaveBeenCalled();
     expect(result.current.medications).toContainEqual(newMed);
   });
 
   it('should handle errors', async () => {
-    (MedicationRepository.prototype.getActiveList as Mock).mockRejectedValue(
+    vi.mocked(medicationService.getMedications).mockRejectedValue(
       new Error('Fetch failed')
     );
 
@@ -74,7 +84,7 @@ describe('useMedicationStore', () => {
   });
 
   it('should handle add medication error', async () => {
-    (MedicationRepository.prototype.createMedication as Mock).mockRejectedValue(
+    vi.mocked(medicationService.addMedication).mockRejectedValue(
       new Error('Add failed')
     );
 
@@ -105,8 +115,8 @@ describe('useMedicationStore', () => {
     useMedicationStore.setState({ medications: initialMeds });
 
     const updatedMed = { id: '1', name: 'Aspirin Updated' };
-    (MedicationRepository.prototype.updateMedication as Mock).mockResolvedValue(
-      updatedMed
+    vi.mocked(medicationService.updateMedication).mockResolvedValue(
+      updatedMed as MedicationDefinition
     );
 
     const { result } = renderHook(() => useMedicationStore());
@@ -115,6 +125,9 @@ describe('useMedicationStore', () => {
       await result.current.updateMedication('1', { name: 'Aspirin Updated' });
     });
 
+    expect(medicationService.updateMedication).toHaveBeenCalledWith('1', {
+      name: 'Aspirin Updated',
+    });
     expect(result.current.medications).toEqual([updatedMed]);
     expect(result.current.isLoading).toBe(false);
   });
@@ -125,7 +138,7 @@ describe('useMedicationStore', () => {
     ] as MedicationDefinition[];
     useMedicationStore.setState({ medications: initialMeds });
 
-    (MedicationRepository.prototype.updateMedication as Mock).mockRejectedValue(
+    vi.mocked(medicationService.updateMedication).mockRejectedValue(
       new Error('Update failed')
     );
 
@@ -150,10 +163,7 @@ describe('useMedicationStore', () => {
     ] as MedicationDefinition[];
     useMedicationStore.setState({ medications: initialMeds });
 
-    (MedicationRepository.prototype.archive as Mock).mockResolvedValue({
-      id: '1',
-      isArchived: true,
-    });
+    vi.mocked(medicationService.archiveMedication).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useMedicationStore());
 
@@ -161,6 +171,7 @@ describe('useMedicationStore', () => {
       await result.current.archiveMedication('1');
     });
 
+    expect(medicationService.archiveMedication).toHaveBeenCalledWith('1');
     expect(result.current.medications).toEqual([{ id: '2', name: 'Benadryl' }]);
     expect(result.current.isLoading).toBe(false);
   });
@@ -171,7 +182,7 @@ describe('useMedicationStore', () => {
     ] as MedicationDefinition[];
     useMedicationStore.setState({ medications: initialMeds });
 
-    (MedicationRepository.prototype.archive as Mock).mockRejectedValue(
+    vi.mocked(medicationService.archiveMedication).mockRejectedValue(
       new Error('Archive failed')
     );
 

--- a/src/store/useMedicationStore.ts
+++ b/src/store/useMedicationStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
-import { MedicationRepository } from '@repositories/MedicationRepository';
+import { medicationService } from '@services/medicationService';
 import type {
   MedicationDefinition,
   MedicationDefinitionCreateInput,
@@ -20,8 +20,6 @@ export interface MedicationState {
   archiveMedication: (id: string) => Promise<void>;
 }
 
-const repository = new MedicationRepository();
-
 export const useMedicationStore = create(
   devtools<MedicationState>((set) => ({
     medications: [],
@@ -31,7 +29,7 @@ export const useMedicationStore = create(
     fetchMedications: async () => {
       set({ isLoading: true, error: null });
       try {
-        const medications = await repository.getActiveList({
+        const medications = await medicationService.getMedications({
           orderBy: 'name',
         });
         set({ medications, isLoading: false });
@@ -49,7 +47,7 @@ export const useMedicationStore = create(
     addMedication: async (input) => {
       set({ isLoading: true, error: null });
       try {
-        const newMedication = await repository.createMedication(input);
+        const newMedication = await medicationService.addMedication(input);
         set((state) => ({
           medications: [...state.medications, newMedication].sort((a, b) =>
             a.name.localeCompare(b.name)
@@ -69,7 +67,7 @@ export const useMedicationStore = create(
     updateMedication: async (id, updates) => {
       set({ isLoading: true, error: null });
       try {
-        const updatedMedication = await repository.updateMedication(
+        const updatedMedication = await medicationService.updateMedication(
           id,
           updates
         );
@@ -94,7 +92,7 @@ export const useMedicationStore = create(
     archiveMedication: async (id) => {
       set({ isLoading: true, error: null });
       try {
-        await repository.archive(id);
+        await medicationService.archiveMedication(id);
         set((state) => ({
           medications: state.medications.filter((med) => med.id !== id),
           isLoading: false,


### PR DESCRIPTION
## Summary

Closes Tier 2 #6 from the eng review. `useMedicationStore` was the only Zustand store reaching across the service layer to instantiate a repository directly — every other store goes Component → Hook → Store → Service → Repository. Now medications match.

### What changed

- **New `src/services/medicationService.ts`**, same shape as `feedingService` (class + singleton export). Methods: `getMedications`, `addMedication`, `updateMedication`, `archiveMedication`.
- **`src/store/useMedicationStore.ts`** imports `medicationService` instead of `MedicationRepository`. No Firestore-adjacent code left in the store layer.
- **Tests**:
  - 4 new tests in `src/services/medicationService.test.ts` (delegate-shape contract, matches `feedingService.test.ts`)
  - `src/store/useMedicationStore.test.ts` rewritten to mock the service rather than the repository — clearer seam, decoupled from Firestore wiring

### Why this matters

Service is where you'd add cross-entity invariants, analytics events, validation. Skipping it meant any future business rule for medications would either get jammed into the store (worst) or sprinkled across components (still bad). `vetService` already shows what good service code looks like — medication now has the same seam to grow into.

## Follow-up flagged

While doing this I confirmed via grep that **`src/store/usePetMedicationStore.ts` has the same violation** (imports `PetMedicationRepository` directly at lines 3, 43, 69, 96, 128). The original eng review only called out `useMedicationStore`; this is a second instance that should get the same treatment. Not in this PR to keep scope tight — track as a quick follow-up.

```
$ grep -rn "from '@repositories/" src/store/
src/store/usePetMedicationStore.ts:3:import { PetMedicationRepository } ...
```

After both are fixed, the rule "no store imports `@repositories`" can be enforced via an ESLint `no-restricted-imports` rule.

## Test plan

- [x] `pnpm exec tsc -b` clean
- [x] New tests pass (`vitest run src/services/medicationService.test.ts src/store/useMedicationStore.test.ts` — 12 passed)
- [x] Full suite: 559 passed, 1 skipped, 88 files (was 555 — +4 new service tests)
- [x] Pre-push hook (build + test:coverage) green before push
- [ ] CI green