### PR TITLE
chore: knip cleanup 2 of 3 - localize 23 unused exported types

### DIFF
--- a/src/components/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-export type ErrorBoundaryProps = {
+type ErrorBoundaryProps = {
   children: React.ReactNode;
   fallbackText?: string;
   'data-testid'?: string;

--- a/src/components/common/ErrorIndicator/ErrorIndicator.tsx
+++ b/src/components/common/ErrorIndicator/ErrorIndicator.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Alert } from '@mui/material';
 
-export type ErrorIndicatorProps = {
+type ErrorIndicatorProps = {
   text?: string; // optional override of localized default
   role?: React.AriaRole; // a11y role
   ariaLive?: 'polite' | 'assertive' | 'off';

--- a/src/components/common/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/common/LanguageSelector/LanguageSelector.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { preloadLanguage } from '@i18n';
 
-export type LanguageSelectorProps = {
+type LanguageSelectorProps = {
   supportedLocales?: string[];
   labelId?: string;
 };

--- a/src/components/common/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/common/LoadingIndicator/LoadingIndicator.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 
-export type LoadingIndicatorProps = {
+type LoadingIndicatorProps = {
   text?: string; // optional override of localized default
   role?: React.AriaRole; // a11y role
   ariaLive?: 'polite' | 'assertive' | 'off';

--- a/src/features/authentication/components/GoogleAuth/GoogleLoginButton.tsx
+++ b/src/features/authentication/components/GoogleAuth/GoogleLoginButton.tsx
@@ -5,7 +5,7 @@ import { loadNamespace } from '@i18n';
 import { logger } from '@services/logService';
 import { Button } from '@mui/material';
 
-export type LoginButtonProps = {
+type LoginButtonProps = {
   className?: string;
   disabled?: boolean;
 };

--- a/src/features/medications/types.ts
+++ b/src/features/medications/types.ts
@@ -51,7 +51,7 @@ export interface MedicationDefinition extends BaseEntity {
   isArchived: boolean;
 }
 
-export interface ScheduleConfig {
+interface ScheduleConfig {
   timesOfDay?: string[] | null; // HH:mm in local time
   intervalHours?: number | null;
   intervalDays?: number | null;

--- a/src/features/pets/components/PetForm.tsx
+++ b/src/features/pets/components/PetForm.tsx
@@ -247,5 +247,3 @@ export function PetForm({
     </form>
   );
 }
-
-export type { Pet } from '@features/pets/types';

--- a/src/features/pets/hooks/usePetVets.ts
+++ b/src/features/pets/hooks/usePetVets.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { usePetVetsStore } from '@store/petVets.store';
 import type { PetVetLink, Vet, VetId, PetVetRole } from '@models/vets';
 
-export interface UsePetVetsResult {
+interface UsePetVetsResult {
   links: Array<{ link: PetVetLink; vet: Vet }>;
   loading: boolean;
   error: string | null;

--- a/src/features/veterinarians/components/VetSelector.tsx
+++ b/src/features/veterinarians/components/VetSelector.tsx
@@ -16,7 +16,7 @@ import { useCreateVet } from '../hooks/useCreateVet';
 import { useAuthStore } from '@store/auth.store';
 import { logger } from '@services/logService';
 
-export type VetSelectorProps = {
+type VetSelectorProps = {
   label?: string;
   onSelect: (vet: Vet) => void;
 };

--- a/src/features/veterinarians/hooks/useCreateVet.ts
+++ b/src/features/veterinarians/hooks/useCreateVet.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { vetService, type CreateVetInput } from '@services/vetService';
 import type { Vet } from '@models/vets';
 
-export interface UseCreateVetResult {
+interface UseCreateVetResult {
   createVet: (input: CreateVetInput) => Promise<Vet>;
   loading: boolean;
   error: unknown;

--- a/src/features/veterinarians/hooks/useEditVet.ts
+++ b/src/features/veterinarians/hooks/useEditVet.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { vetService, type UpdateVetInput } from '@services/vetService';
 import type { Vet, VetId } from '@models/vets';
 
-export interface UseEditVetResult {
+interface UseEditVetResult {
   vet: Vet | null;
   loading: boolean;
   loadError: unknown;

--- a/src/features/veterinarians/hooks/useVetSearch.ts
+++ b/src/features/veterinarians/hooks/useVetSearch.ts
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import { vetService } from '@services/vetService';
 import type { Vet } from '@models/vets';
 
-export interface UseVetSearchOptions {
+interface UseVetSearchOptions {
   /** Debounce window in ms before refetching when `term` changes. 0 disables debounce. */
   debounceMs?: number;
 }
 
-export interface UseVetSearchResult {
+interface UseVetSearchResult {
   vets: Vet[];
   loading: boolean;
 }

--- a/src/services/analytics/analytics.ts
+++ b/src/services/analytics/analytics.ts
@@ -2,7 +2,7 @@
 // Minimal, no-op analytics tracker for anonymized events.
 // In production, wire to a real analytics provider.
 
-export type AnalyticsEvent =
+type AnalyticsEvent =
   | 'vet_created'
   | 'vet_updated'
   | 'vet_archived'
@@ -11,7 +11,7 @@ export type AnalyticsEvent =
   | 'vet_primary_set'
   | 'vet_search';
 
-export type AnalyticsProps = Record<string, unknown>;
+type AnalyticsProps = Record<string, unknown>;
 
 export function isTestMode(): boolean {
   return import.meta.env.MODE === 'test';

--- a/src/services/petService.ts
+++ b/src/services/petService.ts
@@ -6,7 +6,7 @@ import type {
   Pet,
 } from '@features/pets/types';
 
-export type UpdatePetInput = {
+type UpdatePetInput = {
   name: string;
   breed: string;
 };

--- a/src/store/petVets.store.ts
+++ b/src/store/petVets.store.ts
@@ -3,13 +3,13 @@ import { devtools } from 'zustand/middleware';
 import { petVetService } from '@services/petVetService';
 import type { PetVetLink, Vet, VetId, PetVetRole } from '@models/vets';
 
-export interface PetVetsEntry {
+interface PetVetsEntry {
   links: Array<{ link: PetVetLink; vet: Vet }>;
   loading: boolean;
   error: string | null;
 }
 
-export interface PetVetsState {
+interface PetVetsState {
   /** Keyed by petId so multiple PetCards / pages share the cache. */
   byPetId: Record<string, PetVetsEntry>;
   /**

--- a/src/store/theme.store.ts
+++ b/src/store/theme.store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export type ThemeMode = 'light' | 'dark';
+type ThemeMode = 'light' | 'dark';
 
 interface ThemeState {
   mode: ThemeMode;

--- a/src/testUtils/mocks/mockStores.ts
+++ b/src/testUtils/mocks/mockStores.ts
@@ -5,7 +5,7 @@ import { makeZustandSelectorMock } from '@testUtils/mocks/mockZustand';
 import { useSyncExternalStore } from 'react';
 
 // Note: PetsState is not exported from the store by default; we provide a minimal compatible shape for tests.
-export type TestPetsState = {
+type TestPetsState = {
   pets: Pet[];
   isFetching?: boolean;
   fetchError?: Error | null;
@@ -200,10 +200,7 @@ export function createPetsStoreMock(initial: Partial<TestPetsState> = {}) {
   };
 }
 
-export type TestAuthState = Pick<
-  AuthState,
-  'user' | 'initializing' | 'error'
-> & {
+type TestAuthState = Pick<AuthState, 'user' | 'initializing' | 'error'> & {
   initAuthListener?: () => void;
   signInWithGoogle?: () => Promise<void>;
   signOut?: () => Promise<void>;

--- a/src/testUtils/mocks/mockZustand.ts
+++ b/src/testUtils/mocks/mockZustand.ts
@@ -8,7 +8,7 @@
 //     action: vi.fn(...)
 //   })))
 
-export type StateOrFactory<TState> = TState | (() => TState);
+type StateOrFactory<TState> = TState | (() => TState);
 
 export function makeZustandSelectorMock<TState>(
   stateOrFactory: StateOrFactory<TState>

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -2,7 +2,7 @@
 // Runtime default: crypto.randomUUID when available; otherwise a random fallback
 // Tests can inject a deterministic generator via setIdGenerator
 
-export type IdGenerator = () => string;
+type IdGenerator = () => string;
 
 function defaultIdGenerator(): string {
   const rnd = (len = 8) =>


### PR DESCRIPTION
Stacked on top of #142 (which is stacked on #141).

## Summary
Removed the \`export\` keyword from 23 types/interfaces that are not imported outside their defining file:

- **Component Props (7):** \`ErrorBoundaryProps\`, \`ErrorIndicatorProps\`, \`LanguageSelectorProps\`, \`LoadingIndicatorProps\`, \`LoginButtonProps\`, \`VetSelectorProps\`. Also deleted a stale unused \`Pet\` type re-export in \`PetForm.tsx\`.
- **Hook result types (5):** \`UsePetVetsResult\`, \`UseCreateVetResult\`, \`UseEditVetResult\`, \`UseVetSearchOptions\`, \`UseVetSearchResult\`.
- **Test utility types (4):** \`TestPetsState\`, \`TestAuthState\`, \`StateOrFactory\`, \`IdGenerator\`.
- **Service/store types (4):** \`AnalyticsEvent\`, \`AnalyticsProps\`, \`PetVetsEntry\`, \`PetVetsState\`.
- **Misc (3):** \`UpdatePetInput\`, \`ScheduleConfig\`, \`ThemeMode\`.

No behavior change — all of these types are still used inside their files.

## Impact
Closes **23 of 39** remaining knip findings. After this PR: 5 type exports + 8 value exports + 3 duplicate exports remain (handled in PR 3).

## Test plan
- [x] \`pnpm exec tsc -b\` clean
- [x] \`pnpm run lint\` clean
- [x] \`pnpm run test:unit\` — 597 passed / 1 skipped
- [ ] CI green