### PR TITLE
chore: knip cleanup 3 of 3 - localize values + dedupe exports (knip exits 0)

### DIFF
--- a/src/components/common/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/common/LanguageSelector/LanguageSelector.tsx
@@ -93,5 +93,3 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
     </FormControl>
   );
 };
-
-export default LanguageSelector;

--- a/src/features/misc/pages/NotFoundPage.tsx
+++ b/src/features/misc/pages/NotFoundPage.tsx
@@ -20,5 +20,3 @@ export function NotFoundPage() {
     </main>
   );
 }
-
-export default NotFoundPage;

--- a/src/features/pets/components/PetCard.tsx
+++ b/src/features/pets/components/PetCard.tsx
@@ -27,7 +27,7 @@ import { logger } from '@services/logService';
 // - Header image
 // - Displays provided pet name and breed
 // - Clicking the card navigates to the PetDetailsPage for the pet
-export function PetCard({ pet }: { pet: Pet }) {
+function PetCard({ pet }: { pet: Pet }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const petActionsEnabled = useFeatureFlag('petActionsEnabled');

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -11,7 +11,7 @@ const saved =
 const initialLng = (saved || envDefault || 'en').split('-')[0];
 
 // Keep an authoritative list of app namespaces in one place
-export const APP_NAMESPACES = [
+const APP_NAMESPACES = [
   'common',
   'petList',
   'petProperties',
@@ -68,5 +68,3 @@ i18n.on('languageChanged', (lng) => {
   // Ensure all namespaces are present for the new language
   void preloadLanguage(lng);
 });
-
-export default i18n;

--- a/src/models/vets.ts
+++ b/src/models/vets.ts
@@ -4,7 +4,7 @@
 import type { ArchivableEntity } from '@repositories/types.ts';
 
 export type VetId = string;
-export type PetVetLinkId = string;
+type PetVetLinkId = string;
 
 export type VetAddress = {
   line1?: string;

--- a/src/repositories/storageRepository.ts
+++ b/src/repositories/storageRepository.ts
@@ -8,7 +8,7 @@ import {
 import { storage } from '../firebase';
 import { logger } from '@services/logService';
 
-export interface StorageRepository {
+interface StorageRepository {
   uploadFile(
     path: string,
     file: File,

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -48,7 +48,7 @@ export interface FilterCriteria {
 }
 
 // Sort criteria for ordered results
-export interface SortCriteria {
+interface SortCriteria {
   field: string;
   direction: 'asc' | 'desc';
 }
@@ -59,13 +59,6 @@ export interface AdvancedQueryOptions extends Omit<QueryOptions, 'filters'> {
   filters?: FilterCriteria[];
   sort?: SortCriteria[];
   searchTerm?: string;
-}
-
-// Response wrapper for operations that may fail
-export interface ServiceResult<T> {
-  success: boolean;
-  data?: T;
-  error?: ServiceError;
 }
 
 // Standardized error structure
@@ -84,11 +77,3 @@ export const ErrorCodes = {
   FIRESTORE_ERROR: 'FIRESTORE_ERROR',
   UNKNOWN_ERROR: 'UNKNOWN_ERROR',
 } as const;
-
-// Pagination support for list operations
-export interface PaginatedResult<T> {
-  items: T[];
-  total: number;
-  hasNext: boolean;
-  nextCursor?: string;
-}

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -2,7 +2,7 @@ import type { User } from '@models/User';
 import { BaseRepository } from './base/BaseRepository.ts';
 import { COLLECTIONS } from '@repositories/config.ts';
 
-export class UserRepository extends BaseRepository<User> {
+class UserRepository extends BaseRepository<User> {
   constructor() {
     super(COLLECTIONS.USERS);
   }

--- a/src/services/analytics/analytics.ts
+++ b/src/services/analytics/analytics.ts
@@ -13,7 +13,7 @@ type AnalyticsEvent =
 
 type AnalyticsProps = Record<string, unknown>;
 
-export function isTestMode(): boolean {
+function isTestMode(): boolean {
   return import.meta.env.MODE === 'test';
 }
 

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -28,7 +28,7 @@ export async function ensurePersistence(): Promise<void> {
   await setPersistence(auth, browserLocalPersistence);
 }
 
-export function mapUser(user: FirebaseUser | null): AppUser | null {
+function mapUser(user: FirebaseUser | null): AppUser | null {
   if (!user) return null;
   return {
     uid: user.uid,


### PR DESCRIPTION
Final knip cleanup. Stacked on #143 → #142 → #141.

After this PR \`pnpm knip\` exits 0.

## Localize internal-only values (remove \`export\`)
- \`UserRepository\` class — only the \`userRepository\` instance is consumed
- \`isTestMode\` — called only within \`analytics.ts\`
- \`mapUser\` — called only within \`authService.ts\`
- \`APP_NAMESPACES\` — used only within \`i18n.ts\`

## Localize repository-layer types (remove \`export\`)
- \`PetVetLinkId\`, \`StorageRepository\`, \`SortCriteria\`

## Delete genuinely unused interfaces
No internal or external consumers — safe to remove:
- \`ServiceResult\`, \`PaginatedResult\` in \`repositories/types.ts\`
- \`default\` export of \`i18n.ts\` (consumers use the side-effect import \`import './i18n.ts'\` from \`main.tsx\`)

## Dedupe duplicate exports
Keep the form actually imported:
- \`LanguageSelector\`: keep named, delete default (NavigationBar imports named)
- \`NotFoundPage\`: keep named, delete default (AppRoutes imports named)
- \`PetCard\`: keep default, drop \`export\` on the named function (PetList + tests import default)

## Test plan
- [x] \`pnpm exec tsc -b\` clean
- [x] \`pnpm run lint\` clean
- [x] \`pnpm run test:unit\` — 597 passed / 1 skipped
- [x] \`pnpm knip\` — **exit 0** (was 46 findings on PR #141)
- [ ] CI green

## Follow-up
A 4th PR will wire \`pnpm knip\` into \`.github/workflows/ci-pr.yml\` so regressions can't slip back in.