### PR TITLE
chore: wire knip into CI to gate dead-code regressions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Dead code (knip)
+        run: pnpm knip --no-progress
+
       - name: Test (coverage gate)
         run: pnpm run test:coverage
 


### PR DESCRIPTION
Stacked on top of #144 (final cleanup) — should be the last in the knip stack.

## Summary
Adds a \`Dead code (knip)\` step to \`.github/workflows/ci-pr.yml\` between lint and the test/coverage step.

## Why this ordering
- After lint (cheap, ~3s) so we keep the fail-fast pattern
- Before \`test:coverage\` and \`build\` (expensive) so dead code gets caught before we burn the slow steps
- After PRs #142, #143, #144 land, \`pnpm knip\` exits 0 — this step then prevents regressions

## Test plan
- [ ] CI runs the new step and stays green on this branch (after parents merge)
- [ ] Verify a deliberately-introduced unused export would fail this step (manual sanity check, not in this PR)