### PR TITLE
chore: fix husky pre-commit hook to not sweep untracked files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-pnpm run format
-git add .
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
-      "pnpm run lint"
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "**/*.{json,md,css,html,yml,yaml}": [
+      "prettier --write"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Problem
The previous pre-commit hook ran:

\`\`\`
pnpm run format   # prettier on entire repo
git add .         # picks up ALL untracked files
npx lint-staged   # lint-staged config also called whole-repo \`pnpm run lint\`
\`\`\`

Two bugs compounded:

1. **\`git add .\` swept untracked files into commits.** During the recent knip cleanup work I had to repeatedly stash an unrelated session-log file (\`analyze-dog-log-codebase-session-log.md\`) before each commit to avoid this. Worse case, this could include \`.env.local\`, scratch files, half-baked experiments, etc.
2. **lint-staged wasn't actually scoped to staged files.** The config invoked \`pnpm run lint\` which runs \`eslint .\` on the whole repo. So lint-staged was just a slow alias for whole-repo lint.

## Fix
- \`.husky/pre-commit\`: just \`npx lint-staged\`
- \`package.json\` lint-staged config: run \`prettier --write\` then \`eslint --fix\` on the matched staged files. lint-staged automatically re-stages modifications.

## Verified live
Committed this branch with an untracked file present in the worktree — it stayed untracked. Previously, that file would have been pulled into the commit by \`git add .\`.

## Test plan
- [x] Commit on this branch with an untracked file present — untracked file is NOT swept in
- [ ] CI green (no behavior change in actual lint/format rules)
- [ ] Future commits format/lint only the staged files