### PR TITLE
fix: deploy firestore rules correctly + surface AddPet errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "knip:fix": "knip --fix --allow-remove-files",
     "start:firebase": "firebase emulators:start --only auth,firestore,storage",
     "prepare": "husky",
-    "deploy:dev": "firebase use dev && firebase deploy --only hosting,firestore.rules,storage",
-    "deploy:staging": "firebase use staging && firebase deploy --only hosting,firestore.rules,storage"
+    "deploy:dev": "firebase use dev && firebase deploy --only hosting,firestore:rules,storage",
+    "deploy:staging": "firebase use staging && firebase deploy --only hosting,firestore:rules,storage"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [

--- a/src/features/medications/components/DoseLogForm.test.tsx
+++ b/src/features/medications/components/DoseLogForm.test.tsx
@@ -151,6 +151,8 @@ describe('DoseLogForm', () => {
     });
   });
 
+  // Heavy interaction test (clears + types into multiple inputs, multiple combobox selects).
+  // Default 5s timeout is tight on slower environments (husky pre-push under load).
   it('submits form with modified data', async () => {
     const user = userEvent.setup();
     render(
@@ -207,7 +209,7 @@ describe('DoseLogForm', () => {
         })
       );
     });
-  });
+  }, 10000);
 
   it('validates required fields', async () => {
     const { container } = render(

--- a/src/features/pets/pages/AddPetPage.test.tsx
+++ b/src/features/pets/pages/AddPetPage.test.tsx
@@ -274,6 +274,41 @@ describe('AddPetPage', () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  it('shows an error alert and stays on page when addPet rejects', async () => {
+    petsMock.actions.addPet.mockRejectedValueOnce(
+      new Error('Missing or insufficient permissions.')
+    );
+
+    vi.doMock('@features/pets/components/PetForm', () => ({
+      PetForm: (props: {
+        onSubmit: (pet: unknown) => void | Promise<void>;
+      }) => {
+        const testPet = {
+          name: 'Rover',
+          breed: 'Hound',
+          birthDate: new Date('2020-01-02T00:00:00.000Z'),
+        };
+        return (
+          <div>
+            <button onClick={() => props.onSubmit(testPet)}>OK</button>
+          </div>
+        );
+      },
+    }));
+
+    const module = await import('./AddPetPage');
+    const AddPetPage = module.default;
+
+    const user = userEvent.setup();
+    await renderWithProviders(<AddPetPage />);
+
+    await user.click(await screen.findByRole('button', { name: /ok/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/missing or insufficient permissions/i);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it('accepts dirty cancel via keyboard: Tab to Yes and Space to confirm; navigates to /pets', async () => {
     // Provide a minimal PetForm that can toggle dirty state and trigger cancel
     vi.doMock('@features/pets/components/PetForm', () => ({

--- a/src/features/pets/pages/AddPetPage.tsx
+++ b/src/features/pets/pages/AddPetPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Alert } from '@mui/material';
 import { PetForm } from '@features/pets/components/PetForm';
 import type { Pet } from '@features/pets/types';
 import { usePetsStore } from '@store/pets.store';
@@ -26,6 +27,7 @@ export default function AddPetPage() {
   const navigate = useNavigate();
   const [showModal, setShowModal] = useState(false);
   const [formDirty, setFormDirty] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   // petProperties
   useEffect(() => {
     let mounted = true;
@@ -41,12 +43,23 @@ export default function AddPetPage() {
   if (!nsReady) return null;
 
   async function handleSubmit(pet: Pet) {
-    await addPet({
-      name: pet.name,
-      breed: pet.breed,
-      birthDate: pet.birthDate,
-    });
-    navigate('/pets');
+    setSubmitError(null);
+    try {
+      await addPet({
+        name: pet.name,
+        breed: pet.breed,
+        birthDate: pet.birthDate,
+      });
+      navigate('/pets');
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : t('errors.savePetFailed', {
+              defaultValue: 'Failed to save pet. Please try again.',
+            });
+      setSubmitError(message);
+    }
   }
 
   function handleCancel() {
@@ -69,6 +82,11 @@ export default function AddPetPage() {
 
   return (
     <>
+      {submitError && (
+        <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+          {submitError}
+        </Alert>
+      )}
       <PetForm
         initialValues={newPetInitialValues}
         onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary

- **Deploy script bug**: `deploy:dev` and `deploy:staging` used `firestore.rules` (dot) in `--only`, which is not valid Firebase CLI syntax. The correct form is `firestore:rules` (colon). Result: every staging/dev deploy since this script was committed silently failed to push Firestore rules. The original Firebase default open-rules (with a 2025-12-02 expiration) remained in production. Once that date passed, all authenticated writes started returning `permission-denied` — surfacing as "click OK on Add Pet, nothing happens, no pet saved."
- **Silent failure in AddPetPage**: `handleSubmit` had no try/catch, so the rejected promise from `addPet` was swallowed. The user saw no error, no toast, no inline message — just silence. This is what hid the expired-rules problem from view for ~5 months.
- **Flaky test**: Bumped the timeout on one DoseLogForm test that times out under husky pre-push (default 5s isn't enough on slower environments; the test does heavy user-event interactions). Unblocks future pushes from this branch and others.

Rules were also pushed to staging out-of-band via `firebase deploy --only firestore:rules` to immediately unblock the staging environment.

## Files

- `package.json` — `firestore.rules` → `firestore:rules` in both deploy scripts
- `src/features/pets/pages/AddPetPage.tsx` — try/catch around `addPet`, MUI Alert renders the error message, falls back to an i18n key with inline defaultValue
- `src/features/pets/pages/AddPetPage.test.tsx` — new test covering the rejected-`addPet` path
- `src/features/medications/components/DoseLogForm.test.tsx` — timeout bump to 10s on the heavy-interaction test

## Test plan

- [x] `pnpm run test:unit` — 598 pass, 1 skipped
- [x] `pnpm run test:coverage` — same
- [x] `pnpm exec tsc -b` — clean
- [x] `pnpm run lint` — clean
- [x] New test (`AddPetPage > shows an error alert and stays on page when addPet rejects`) verifies the visible error path
- [ ] After merge: redeploy to dev with `pnpm run deploy:dev` and confirm rules push (the staging push was already done out-of-band)
- [ ] After merge: smoke-test Add Pet on staging — should now succeed, and any future Firestore failure should render an Alert