### PR TITLE
fix: surface PetMedicationsPage errors, stop swallowing rejections

### DIFF
--- a/src/features/medications/pages/PetMedicationsPage.test.tsx
+++ b/src/features/medications/pages/PetMedicationsPage.test.tsx
@@ -301,4 +301,42 @@ describe('PetMedicationsPage', () => {
     expect(screen.getByText('Medications')).toBeInTheDocument();
     expect(mockFetchPetMedications).toHaveBeenCalledWith('pet-1');
   });
+
+  it('should keep dose log dialog open and surface error when addDoseLog rejects', async () => {
+    mockAddDoseLog.mockRejectedValueOnce(
+      new Error('Missing or insufficient permissions.')
+    );
+    vi.mocked(useDoseLogStore).mockReturnValue({
+      addDoseLog: mockAddDoseLog,
+      error: 'Missing or insufficient permissions.',
+    } as unknown as DoseLogState);
+
+    const user = userEvent.setup();
+    render(<PetMedicationsPage />);
+
+    await user.click(screen.getByLabelText('log dose'));
+    await user.click(screen.getByText('Submit Dose'));
+
+    expect(mockAddDoseLog).toHaveBeenCalledTimes(1);
+    // Dialog stays open so the user can retry without re-entering data.
+    expect(screen.getByText('Dose Log Form')).toBeInTheDocument();
+    // Error is rendered.
+    expect(
+      screen.getByText('Missing or insufficient permissions.')
+    ).toBeInTheDocument();
+  });
+
+  it('should not throw an unhandled rejection when deactivatePetMedication fails', async () => {
+    mockDeactivatePetMedication.mockRejectedValueOnce(new Error('boom'));
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const user = userEvent.setup();
+    render(<PetMedicationsPage />);
+
+    const deleteButtons = screen.getAllByLabelText('delete');
+    // Should not throw; the click handler swallows the rejection so the
+    // store-driven error Alert can render the message instead.
+    await expect(user.click(deleteButtons[0])).resolves.toBeUndefined();
+    expect(mockDeactivatePetMedication).toHaveBeenCalledWith('pet-1', 'pm-1');
+  });
 });

--- a/src/features/medications/pages/PetMedicationsPage.tsx
+++ b/src/features/medications/pages/PetMedicationsPage.tsx
@@ -45,7 +45,7 @@ export const PetMedicationsPage = ({
   } = usePetMedicationStore();
   const { medications, fetchMedications: fetchDefinitions } =
     useMedicationStore();
-  const { addDoseLog } = useDoseLogStore();
+  const { addDoseLog, error: doseLogError } = useDoseLogStore();
   const medicationsEnabled = useFeatureFlag('medicationsEnabled');
 
   const [isAdding, setIsAdding] = useState(false);
@@ -71,7 +71,11 @@ export const PetMedicationsPage = ({
       petId &&
       window.confirm(t('medications.confirmDeactivate', 'Are you sure?'))
     ) {
-      await deactivatePetMedication(petId, medId);
+      try {
+        await deactivatePetMedication(petId, medId);
+      } catch {
+        // Error state is already set on the store and rendered above.
+      }
     }
   };
 
@@ -80,9 +84,13 @@ export const PetMedicationsPage = ({
   };
 
   const handleDoseSubmit = async (input: DoseLogCreateInput) => {
-    if (petId) {
+    if (!petId) return;
+    try {
       await addDoseLog(petId, input);
       setSelectedMedication(null);
+    } catch {
+      // Error state is set on useDoseLogStore and rendered below.
+      // Keep the dialog open so the user can retry without re-entering data.
     }
   };
 
@@ -121,7 +129,16 @@ export const PetMedicationsPage = ({
       </Box>
 
       {isLoading && <CircularProgress />}
-      {error && <Alert severity="error">{error}</Alert>}
+      {error && (
+        <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      {doseLogError && (
+        <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+          {doseLogError}
+        </Alert>
+      )}
 
       {!isLoading && medicationsList.length === 0 && (
         <Paper sx={{ p: 3, textAlign: 'center' }}>


### PR DESCRIPTION
## Summary

Audit follow-up to #148. Scanned every form/page that awaits a store mutation. All other paths (`EditPetPage`, `AddVetPage`, `EditVetPage`, `DoseLogForm`, `PetMedicationForm`, `MedicationCatalogDialog`, `FeedingForm`, `usePetDetails`) already have proper try/catch + visible error rendering. Two holes remained, both on `PetMedicationsPage`:

- **`handleDoseSubmit`** awaited `addDoseLog` with no try/catch, and `useDoseLogStore.error` was never rendered on the page. A failed dose-log save was completely silent — same class of bug as the original AddPet failure.
- **`handleDeactivate`** awaited `deactivatePetMedication` with no try/catch. The petMedicationStore's `error` was rendered, but the click handler produced an unhandled promise rejection because the store re-throws.

## Changes

- `PetMedicationsPage.tsx`:
  - try/catch in both handlers.
  - `handleDoseSubmit` keeps the dialog open on failure so the user can retry without losing form state.
  - Render `useDoseLogStore.error` in a second Alert next to the existing one.
- `PetMedicationsPage.test.tsx`:
  - New test: dose log dialog stays open and error renders when `addDoseLog` rejects.
  - New test: deactivate failure does not throw an unhandled rejection.

## Test plan

- [x] `pnpm run test:unit` — 600 pass, 1 skipped (was 598 before)
- [x] `pnpm exec tsc -b` — clean
- [x] `pnpm run lint` — clean
- [ ] After merge: try logging a dose against an offline/restricted state on staging — confirm the dialog stays open with the error visible