### PR TITLE
feat: add Caregiver theme alongside Light and Dark

### DIFF
--- a/src/features/theme/components/AppThemeProvider.test.tsx
+++ b/src/features/theme/components/AppThemeProvider.test.tsx
@@ -8,10 +8,16 @@ import { useTheme } from '@mui/material';
 // Mock useFeatureFlag
 const useFeatureFlagSpy = vi.spyOn(featureFlagsHooks, 'useFeatureFlag');
 
-// Helper component to check the current theme mode
+// Helper component to expose theme details for assertions
 function ThemeChecker() {
   const theme = useTheme();
-  return <div data-testid="theme-mode">{theme.palette.mode}</div>;
+  return (
+    <>
+      <div data-testid="theme-mode">{theme.palette.mode}</div>
+      <div data-testid="theme-bg">{theme.palette.background.default}</div>
+      <div data-testid="theme-primary">{theme.palette.primary.main}</div>
+    </>
+  );
 }
 
 describe('AppThemeProvider', () => {
@@ -56,9 +62,39 @@ describe('AppThemeProvider', () => {
     expect(screen.getByTestId('theme-mode')).toHaveTextContent('dark');
   });
 
+  it('uses caregiver theme when mode is caregiver and feature flag is enabled', () => {
+    useFeatureFlagSpy.mockReturnValue(true);
+    useThemeStore.setState({ mode: 'caregiver' });
+
+    render(
+      <AppThemeProvider>
+        <ThemeChecker />
+      </AppThemeProvider>
+    );
+
+    // mode resolves to 'dark' under MUI (caregiver palette is dark-mode-based)
+    expect(screen.getByTestId('theme-mode')).toHaveTextContent('dark');
+    // but the warm-dark background and peach primary identify the caregiver palette
+    expect(screen.getByTestId('theme-bg')).toHaveTextContent('#1A1208');
+    expect(screen.getByTestId('theme-primary')).toHaveTextContent('#FFB47A');
+  });
+
   it('forces light theme when feature flag is disabled, even if store is dark', () => {
     useFeatureFlagSpy.mockReturnValue(false);
     useThemeStore.setState({ mode: 'dark' });
+
+    render(
+      <AppThemeProvider>
+        <ThemeChecker />
+      </AppThemeProvider>
+    );
+
+    expect(screen.getByTestId('theme-mode')).toHaveTextContent('light');
+  });
+
+  it('forces light theme when feature flag is disabled, even if store is caregiver', () => {
+    useFeatureFlagSpy.mockReturnValue(false);
+    useThemeStore.setState({ mode: 'caregiver' });
 
     render(
       <AppThemeProvider>

--- a/src/features/theme/components/AppThemeProvider.tsx
+++ b/src/features/theme/components/AppThemeProvider.tsx
@@ -1,19 +1,27 @@
 import type { ReactNode } from 'react';
 import { ThemeProvider, CssBaseline } from '@mui/material';
+import type { Theme } from '@mui/material';
 import { useFeatureFlag } from '@featureFlags/hooks/useFeatureFlag';
 import { useThemeStore } from '@store/theme.store';
-import { lightTheme, darkTheme } from '../theme';
+import type { ThemeMode } from '@store/theme.store';
+import { lightTheme, darkTheme, caregiverTheme } from '../theme';
 
 interface AppThemeProviderProps {
   children: ReactNode;
 }
 
+const themesByMode: Record<ThemeMode, Theme> = {
+  light: lightTheme,
+  dark: darkTheme,
+  caregiver: caregiverTheme,
+};
+
 export function AppThemeProvider({ children }: AppThemeProviderProps) {
   const themesEnabled = useFeatureFlag('themesEnabled');
   const { mode } = useThemeStore();
 
-  const activeMode = themesEnabled ? mode : 'light';
-  const theme = activeMode === 'dark' ? darkTheme : lightTheme;
+  const activeMode: ThemeMode = themesEnabled ? mode : 'light';
+  const theme = themesByMode[activeMode] ?? lightTheme;
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/features/theme/components/ThemeSelector.test.tsx
+++ b/src/features/theme/components/ThemeSelector.test.tsx
@@ -1,11 +1,10 @@
-import { render, screen } from '../../../test-utils';
+import { render, screen, within } from '../../../test-utils';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ThemeSelector } from './ThemeSelector';
 import { useThemeStore } from '@store/theme.store';
 import * as featureFlagsHooks from '@featureFlags/hooks/useFeatureFlag';
 
-// Mock useFeatureFlag
 const useFeatureFlagSpy = vi.spyOn(featureFlagsHooks, 'useFeatureFlag');
 
 describe('ThemeSelector', () => {
@@ -20,29 +19,58 @@ describe('ThemeSelector', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('renders toggle button when feature flag is enabled', () => {
+  it('renders an anchor button when feature flag is enabled', () => {
     useFeatureFlagSpy.mockReturnValue(true);
     render(<ThemeSelector />);
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /theme/i })).toBeInTheDocument();
   });
 
-  it('toggles theme when clicked', async () => {
+  it('opens a menu with three options when clicked', async () => {
     useFeatureFlagSpy.mockReturnValue(true);
     const user = userEvent.setup();
     render(<ThemeSelector />);
 
-    const button = screen.getByRole('button');
+    await user.click(screen.getByRole('button', { name: /theme/i }));
 
-    // Initial state (light) -> shows moon icon (Brightness4)
-    // We can check aria-label or icon presence.
-    // The implementation sets aria-label based on next state.
-    expect(button).toHaveAttribute('aria-label', 'Switch to dark mode');
+    const menu = await screen.findByRole('menu', { name: /theme/i });
+    const items = within(menu).getAllByRole('menuitemradio');
+    expect(items).toHaveLength(3);
+    expect(within(menu).getByText('Light')).toBeInTheDocument();
+    expect(within(menu).getByText('Dark')).toBeInTheDocument();
+    expect(within(menu).getByText('Caregiver')).toBeInTheDocument();
+  });
 
-    await user.click(button);
+  it('marks the current mode with aria-checked=true', async () => {
+    useFeatureFlagSpy.mockReturnValue(true);
+    useThemeStore.setState({ mode: 'caregiver' });
+    const user = userEvent.setup();
+    render(<ThemeSelector />);
 
-    expect(useThemeStore.getState().mode).toBe('dark');
+    await user.click(screen.getByRole('button', { name: /theme/i }));
 
-    // After toggle (dark) -> shows sun icon (Brightness7)
-    expect(button).toHaveAttribute('aria-label', 'Switch to light mode');
+    const menu = await screen.findByRole('menu', { name: /theme/i });
+    const caregiverItem = within(menu).getByRole('menuitemradio', {
+      name: /caregiver/i,
+    });
+    expect(caregiverItem).toBeChecked();
+    const lightItem = within(menu).getByRole('menuitemradio', {
+      name: /light/i,
+    });
+    expect(lightItem).not.toBeChecked();
+  });
+
+  it('sets the chosen mode and closes the menu when an item is picked', async () => {
+    useFeatureFlagSpy.mockReturnValue(true);
+    const user = userEvent.setup();
+    render(<ThemeSelector />);
+
+    await user.click(screen.getByRole('button', { name: /theme/i }));
+    const caregiverItem = await screen.findByRole('menuitemradio', {
+      name: /caregiver/i,
+    });
+    await user.click(caregiverItem);
+
+    expect(useThemeStore.getState().mode).toBe('caregiver');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 });

--- a/src/features/theme/components/ThemeSelector.tsx
+++ b/src/features/theme/components/ThemeSelector.tsx
@@ -1,29 +1,132 @@
-import { IconButton, Tooltip } from '@mui/material';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
-import Brightness7Icon from '@mui/icons-material/Brightness7';
+import { useState } from 'react';
+import {
+  IconButton,
+  Tooltip,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Box,
+} from '@mui/material';
+import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
+import CheckIcon from '@mui/icons-material/Check';
 import { useThemeStore } from '@store/theme.store';
+import type { ThemeMode } from '@store/theme.store';
+import { THEME_MODES } from '@store/theme.store';
 import { useTranslation } from 'react-i18next';
 import { useFeatureFlag } from '@featureFlags/hooks/useFeatureFlag';
+import { lightTheme, darkTheme, caregiverTheme } from '../theme';
+
+const swatchByMode: Record<ThemeMode, { bg: string; accent: string }> = {
+  light: {
+    bg: lightTheme.palette.background.default,
+    accent: lightTheme.palette.primary.main,
+  },
+  dark: {
+    bg: darkTheme.palette.background.default,
+    accent: darkTheme.palette.primary.main,
+  },
+  caregiver: {
+    bg: caregiverTheme.palette.background.default,
+    accent: caregiverTheme.palette.primary.main,
+  },
+};
+
+function Swatch({ mode }: { mode: ThemeMode }) {
+  const { bg, accent } = swatchByMode[mode];
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        width: 18,
+        height: 18,
+        borderRadius: '50%',
+        background: `linear-gradient(135deg, ${bg} 0% 50%, ${accent} 50% 100%)`,
+        border: '1px solid',
+        borderColor: 'divider',
+      }}
+    />
+  );
+}
 
 export function ThemeSelector() {
-  const { mode, toggleMode } = useThemeStore();
+  const { mode, setMode } = useThemeStore();
   const { t } = useTranslation('common');
   const themesEnabled = useFeatureFlag('themesEnabled');
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   if (!themesEnabled) {
     return null;
   }
 
-  const isLight = mode === 'light';
-  const title = isLight
-    ? t('theme.switchToDark', 'Switch to dark mode')
-    : t('theme.switchToLight', 'Switch to light mode');
+  const open = Boolean(anchorEl);
+  const tooltipLabel = t('theme.label', 'Theme');
+
+  const handleOpen = (e: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handlePick = (next: ThemeMode) => {
+    setMode(next);
+    setAnchorEl(null);
+  };
 
   return (
-    <Tooltip title={title}>
-      <IconButton onClick={toggleMode} color="inherit" aria-label={title}>
-        {isLight ? <Brightness4Icon /> : <Brightness7Icon />}
-      </IconButton>
-    </Tooltip>
+    <>
+      <Tooltip title={tooltipLabel}>
+        <IconButton
+          onClick={handleOpen}
+          color="inherit"
+          aria-label={tooltipLabel}
+          aria-haspopup="menu"
+          aria-expanded={open}
+        >
+          <PaletteOutlinedIcon />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        slotProps={{
+          list: { 'aria-label': tooltipLabel, role: 'menu' },
+        }}
+      >
+        {THEME_MODES.map((m) => {
+          const selected = m === mode;
+          const label = t(`theme.modes.${m}`, defaultLabelFor(m));
+          return (
+            <MenuItem
+              key={m}
+              selected={selected}
+              onClick={() => handlePick(m)}
+              aria-checked={selected}
+              role="menuitemradio"
+            >
+              <ListItemIcon>
+                <Swatch mode={m} />
+              </ListItemIcon>
+              <ListItemText primary={label} />
+              {selected && <CheckIcon fontSize="small" />}
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </>
   );
+}
+
+function defaultLabelFor(m: ThemeMode): string {
+  switch (m) {
+    case 'light':
+      return 'Light';
+    case 'dark':
+      return 'Dark';
+    case 'caregiver':
+      return 'Caregiver';
+  }
 }

--- a/src/features/theme/theme.ts
+++ b/src/features/theme/theme.ts
@@ -19,3 +19,41 @@ export const darkTheme = createTheme({
     mode: 'dark',
   },
 });
+
+// Caregiver theme — warm-dark palette designed for the active-incident screen
+// and other caregiving flows. Tone: warm, respectful, mobile-first, dark-only.
+// Source: design memory + wireframe-v4-incident-types.html (2026-04-30 design session).
+export const caregiverTheme = createTheme({
+  ...baseTheme,
+  palette: {
+    mode: 'dark',
+    background: {
+      default: '#1A1208',
+      paper: '#2A1F12',
+    },
+    text: {
+      primary: '#F4E9D8',
+      secondary: 'rgba(244, 233, 216, 0.55)',
+    },
+    primary: {
+      main: '#FFB47A',
+      contrastText: '#1A1208',
+    },
+    secondary: {
+      main: '#A78BFA',
+    },
+    error: {
+      main: '#FF6B5C',
+    },
+    warning: {
+      main: '#F59E0B',
+    },
+    info: {
+      main: '#60A5FA',
+    },
+    success: {
+      main: '#4ADE80',
+    },
+    divider: 'rgba(255, 255, 255, 0.06)',
+  },
+});

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -34,5 +34,15 @@
   "validation": {
     "fileSizeTooLarge": "File size too large (max {{maxSize}}MB)",
     "invalidFileType": "Invalid file type. Please upload an image."
+  },
+  "theme": {
+    "label": "Theme",
+    "switchToDark": "Switch to dark mode",
+    "switchToLight": "Switch to light mode",
+    "modes": {
+      "light": "Light",
+      "dark": "Dark",
+      "caregiver": "Caregiver"
+    }
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -34,5 +34,15 @@
   "validation": {
     "fileSizeTooLarge": "El archivo es demasiado grande (máx {{maxSize}}MB)",
     "invalidFileType": "Tipo de archivo inválido. Por favor sube una imagen."
+  },
+  "theme": {
+    "label": "Tema",
+    "switchToDark": "Cambiar a modo oscuro",
+    "switchToLight": "Cambiar a modo claro",
+    "modes": {
+      "light": "Claro",
+      "dark": "Oscuro",
+      "caregiver": "Cuidador"
+    }
   }
 }

--- a/src/store/theme.store.test.ts
+++ b/src/store/theme.store.test.ts
@@ -11,21 +11,28 @@ describe('useThemeStore', () => {
     expect(useThemeStore.getState().mode).toBe('light');
   });
 
-  it('should set mode', () => {
+  it('should set mode to dark', () => {
     useThemeStore.getState().setMode('dark');
     expect(useThemeStore.getState().mode).toBe('dark');
   });
 
-  it('should toggle mode', () => {
-    useThemeStore.getState().toggleMode();
+  it('should set mode to caregiver', () => {
+    useThemeStore.getState().setMode('caregiver');
+    expect(useThemeStore.getState().mode).toBe('caregiver');
+  });
+
+  it('should cycle modes light -> dark -> caregiver -> light', () => {
+    useThemeStore.getState().cycleMode();
     expect(useThemeStore.getState().mode).toBe('dark');
-    useThemeStore.getState().toggleMode();
+    useThemeStore.getState().cycleMode();
+    expect(useThemeStore.getState().mode).toBe('caregiver');
+    useThemeStore.getState().cycleMode();
     expect(useThemeStore.getState().mode).toBe('light');
   });
 
   it('should persist mode to localStorage', () => {
-    useThemeStore.getState().setMode('dark');
+    useThemeStore.getState().setMode('caregiver');
     const storage = JSON.parse(localStorage.getItem('theme-storage') || '{}');
-    expect(storage.state.mode).toBe('dark');
+    expect(storage.state.mode).toBe('caregiver');
   });
 });

--- a/src/store/theme.store.ts
+++ b/src/store/theme.store.ts
@@ -1,12 +1,18 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-type ThemeMode = 'light' | 'dark';
+export type ThemeMode = 'light' | 'dark' | 'caregiver';
+
+export const THEME_MODES: readonly ThemeMode[] = [
+  'light',
+  'dark',
+  'caregiver',
+] as const;
 
 interface ThemeState {
   mode: ThemeMode;
   setMode: (mode: ThemeMode) => void;
-  toggleMode: () => void;
+  cycleMode: () => void;
 }
 
 export const useThemeStore = create<ThemeState>()(
@@ -14,8 +20,12 @@ export const useThemeStore = create<ThemeState>()(
     (set) => ({
       mode: 'light',
       setMode: (mode) => set({ mode }),
-      toggleMode: () =>
-        set((state) => ({ mode: state.mode === 'light' ? 'dark' : 'light' })),
+      cycleMode: () =>
+        set((state) => {
+          const i = THEME_MODES.indexOf(state.mode);
+          const next = THEME_MODES[(i + 1) % THEME_MODES.length];
+          return { mode: next };
+        }),
     }),
     {
       name: 'theme-storage',


### PR DESCRIPTION
## Summary

Adds a third app-wide MUI theme called **Caregiver** using the warm-dark palette from the prior design-shotgun session (wireframe v4). Replaces the binary IconButton toggle with a popover Menu picker that lists all three themes with color swatches and a current-mode check-mark.

The palette is the visual foundation for the upcoming active-incident screen — getting it landed now de-risks that downstream work.

## What you get

- **Theme tokens** (`src/features/theme/theme.ts`):
  - `background.default: #1A1208` (deep warm dark)
  - `background.paper: #2A1F12`
  - `text.primary: #F4E9D8` (cream)
  - `primary.main: #FFB47A` (peach gold)
  - `error.main: #FF6B5C` (SOS / destructive)
  - Mode-axis: success `#4ADE80`, info `#60A5FA`, warning `#F59E0B`, secondary `#A78BFA` — these align with the wireframe chip set (feed / walk / med / note).
- **Theme store** (`src/store/theme.store.ts`): widen `ThemeMode` to `'light' | 'dark' | 'caregiver'`. Replace `toggleMode` with `cycleMode` (cycles through all three). Persistence key unchanged (`theme-storage`).
- **Provider** (`AppThemeProvider.tsx`): `Record<ThemeMode, Theme>` map for resolution; feature-flag gate behavior preserved.
- **Selector** (`ThemeSelector.tsx`): popover Menu with three `menuitemradio` options, color swatches, current-mode check-mark.
- **i18n**: new keys `theme.label`, `theme.modes.{light,dark,caregiver}` in en + es.

## Tests

- `theme.store.test.ts`: caregiver setMode + 3-way cycleMode + persistence.
- `AppThemeProvider.test.tsx`: caregiver mode resolves to bg `#1A1208` and primary `#FFB47A`. Feature-flag-off forces light from caregiver too.
- `ThemeSelector.test.tsx`: rewritten — opens menu, lists three options, current mode is checked, picking sets the mode and closes.
- `pnpm run test:unit`: 605 pass, 1 skipped (was 600 before).
- `pnpm exec tsc -b` and `pnpm run lint` clean.
- `pnpm run build` succeeds.

## Out of scope (deliberate, deferred)

- **CSS-module hard-coded colors.** `src/styles/FormStyles.module.css` and `src/components/common/ConfirmModal/ConfirmModal.module.css` use hard-coded white backgrounds and blue buttons that will visibly clash with Caregiver mode (and partially with Dark mode, honestly). These are hand-rolled CSS, not MUI components — fixing them requires either migrating to MUI or enabling MUI's CSS variables. Tracked as a follow-up to keep this PR focused on the theme system itself. v1 Caregiver still works; the form/modal surfaces will look off until the follow-up lands.
- **Typography customization** (Playfair Display for pet names, Inter for UI). Defer to the incident-capture work where it actually shows up.
- **Caregiver-light variant.** Design intent is dark-only; revisit only if requested.
- **Settings page** hosting the picker. Header popover Menu is the v1 UX.
- **Removing unused** `theme.switchToDark` / `theme.switchToLight` i18n keys. Tiny follow-up.
- **Default theme change.** Stays `light`.

## Test plan

- [x] `pnpm exec tsc -b` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run test:unit` — 605 pass
- [x] `pnpm run build` succeeds
- [ ] After merge: smoke on dev (`pnpm run dev`) — open the theme picker, verify each of the three modes renders correctly, picking persists across reload.
- [ ] After merge: smoke on staging (`pnpm run deploy:staging`) at iPhone-sized viewport — Caregiver should look right one-thumb. This is the primary target.
- [ ] Note any FormStyles / ConfirmModal visual issues; we'll address in a follow-up that migrates those to themed surfaces.

## Reference

- Design memory: `~/.claude/projects/-Users-edmays-src-dog-log/memory/feedback_dog_log_design_model.md`
- Wireframes: `~/.gstack/projects/ed-mays-dog-log/designs/pet-details-20260430-220703/`
- Plan file: `~/.claude/plans/now-let-s-move-on-cuddly-lantern.md`