### PR TITLE
feat(harness): MVP step 1 — task-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^8.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/react':
         specifier: ^19.1.10
         version: 19.2.14

--- a/scripts/harness/lib/task-parser.test.ts
+++ b/scripts/harness/lib/task-parser.test.ts
@@ -1,0 +1,312 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { nextActionableTask, parseTaskList, type Task } from './task-parser';
+
+const realTasksPath = resolve(
+  __dirname,
+  '../../../docs/specs/incident-capture/03-tasks.md'
+);
+const realMarkdown = readFileSync(realTasksPath, 'utf8');
+const real = parseTaskList(realMarkdown);
+
+function task(parsed: ReturnType<typeof parseTaskList>, id: string): Task {
+  const found = parsed.tasks.find((t) => t.id === id);
+  if (!found) throw new Error(`task ${id} not in parse result`);
+  return found;
+}
+
+describe('parseTaskList — against real 03-tasks.md', () => {
+  it('parses all 47 tasks', () => {
+    expect(real.tasks.length).toBe(47);
+  });
+
+  it('identifies all 6 slices including foundation (slice 0)', () => {
+    expect(real.slices.map((s) => s.index)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(real.slices[0]?.name).toBe('Foundation');
+  });
+
+  it('emits zero warnings on the canonical file', () => {
+    expect(real.warnings).toEqual([]);
+  });
+
+  it('every feature-slice task (slices 0–4) has at least one spec or design citation', () => {
+    // Slice 5 is verify & close — some tasks there cite process docs
+    // (CLAUDE.md, "plan Phase 6") rather than spec/design sections, which is
+    // legitimate. The harness's citation-linter will need a similar carve-out.
+    for (const t of real.tasks) {
+      if (t.slice === 5) continue;
+      const total = t.citations.spec.length + t.citations.design.length;
+      expect(total, `${t.id} has no citations`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every task has a non-null Verify line (methodology requirement)', () => {
+    for (const t of real.tasks) {
+      expect(t.verify, `${t.id} missing Verify`).not.toBeNull();
+    }
+  });
+
+  it('captures the open DQs from the preamble', () => {
+    const ids = real.openDqs.map((d) => d.id);
+    expect(ids).toEqual(['DQ-4', 'DQ-5', 'DQ-8']);
+  });
+
+  it('all tasks start in pending state', () => {
+    for (const t of real.tasks) {
+      expect(t.status).toBe('pending');
+    }
+  });
+
+  it('parses T-01 cite line into spec §5 + design §D3', () => {
+    const t01 = task(real, 'T-01');
+    expect(t01.citations.spec).toEqual([{ kind: 'spec_section', ref: '§5' }]);
+    expect(t01.citations.design).toEqual([
+      { kind: 'design_section', ref: '§D3' },
+    ]);
+  });
+
+  it('parses a multi-citation cite line (T-17)', () => {
+    const t17 = task(real, 'T-17');
+    // T-17 cites: spec BR-6, BR-7, BR-8, BR-9, BR-19, BR-22; design §D3
+    const specRefs = t17.citations.spec.map((c) => c.ref);
+    expect(specRefs).toEqual(
+      expect.arrayContaining(['BR-6', 'BR-7', 'BR-8', 'BR-9', 'BR-19', 'BR-22'])
+    );
+    expect(t17.citations.design).toContainEqual({
+      kind: 'design_section',
+      ref: '§D3',
+    });
+  });
+
+  it('extracts DQ tags from notes (T-19 references DQ-5)', () => {
+    const t19 = task(real, 'T-19');
+    expect(t19.dqTags).toContain('DQ-5');
+  });
+
+  it('preserves slice membership (T-06 is in slice 1, T-37 in slice 4)', () => {
+    expect(task(real, 'T-06').slice).toBe(1);
+    expect(task(real, 'T-37').slice).toBe(4);
+  });
+
+  it('slice taskIds are populated and non-overlapping', () => {
+    const seen = new Set<string>();
+    for (const slice of real.slices) {
+      for (const id of slice.taskIds) {
+        expect(seen.has(id), `${id} in two slices`).toBe(false);
+        seen.add(id);
+      }
+    }
+    expect(seen.size).toBe(47);
+  });
+});
+
+describe('parseTaskList — targeted fixtures', () => {
+  it('handles each status marker', () => {
+    const md = `## Slice 0 — Test
+### \`[ ]\` T-01 — pending one
+- **Verify:** ok
+### \`[~]\` T-02 — in progress one
+- **Verify:** ok
+### \`[x]\` T-03 — done one
+- **Verify:** ok
+### \`[!]\` T-04 — blocked one
+- **Verify:** ok
+`;
+    const p = parseTaskList(md);
+    expect(p.tasks.map((t) => t.status)).toEqual([
+      'pending',
+      'in_progress',
+      'done',
+      'blocked',
+    ]);
+  });
+
+  it('warns when a Verify line is missing', () => {
+    const md = `## Slice 0 — Test
+### \`[ ]\` T-01 — no verify
+- **What:** something
+`;
+    const p = parseTaskList(md);
+    expect(p.warnings).toContain('T-01 has no Verify line.');
+  });
+
+  it('warns on unknown status marker but still emits the task', () => {
+    const md = `## Slice 0 — Test
+### \`[?]\` T-01 — weird marker
+- **Verify:** ok
+`;
+    const p = parseTaskList(md);
+    expect(p.warnings.some((w) => w.includes('unrecognized status'))).toBe(
+      true
+    );
+    expect(p.tasks).toHaveLength(1);
+    expect(p.tasks[0]?.status).toBe('pending');
+  });
+
+  it('warns on tasks before any slice heading', () => {
+    const md = `### \`[ ]\` T-01 — orphan
+- **Verify:** ok
+`;
+    const p = parseTaskList(md);
+    expect(p.warnings.some((w) => w.includes('appears before any slice'))).toBe(
+      true
+    );
+  });
+
+  it('separates spec and design citations even with reversed order', () => {
+    const md = `## Slice 0 — Test
+### \`[ ]\` T-01 — reverse
+- **Cite:** design §D2; spec BR-7
+- **Verify:** ok
+`;
+    const p = parseTaskList(md);
+    expect(p.tasks[0]?.citations.spec).toEqual([{ kind: 'BR', ref: 'BR-7' }]);
+    expect(p.tasks[0]?.citations.design).toEqual([
+      { kind: 'design_section', ref: '§D2' },
+    ]);
+  });
+
+  it('falls back on §N → spec, §DN → design when no spec/design label is present', () => {
+    const md = `## Slice 0 — Test
+### \`[ ]\` T-01 — bare sections
+- **Cite:** §5, §D3
+- **Verify:** ok
+`;
+    const p = parseTaskList(md);
+    expect(p.tasks[0]?.citations.spec).toContainEqual({
+      kind: 'spec_section',
+      ref: '§5',
+    });
+    expect(p.tasks[0]?.citations.design).toContainEqual({
+      kind: 'design_section',
+      ref: '§D3',
+    });
+  });
+
+  it('dedupes repeated citations in a single Cite line', () => {
+    const md = `## Slice 0 — Test
+### \`[ ]\` T-01 — duplicate cites
+- **Cite:** spec BR-7, BR-7, BR-7; design §D3, §D3
+- **Verify:** ok
+`;
+    const p = parseTaskList(md);
+    expect(p.tasks[0]?.citations.spec).toEqual([{ kind: 'BR', ref: 'BR-7' }]);
+    expect(p.tasks[0]?.citations.design).toEqual([
+      { kind: 'design_section', ref: '§D3' },
+    ]);
+  });
+
+  it('captures DQ tags whether bracketed or bare', () => {
+    const md = `## Slice 0 — Test
+### \`[ ]\` T-01 — DQ tags
+- **Verify:** ok
+- **Notes:** [DQ-4] one bracketed; also DQ-5 bare and DQ-4 again.
+`;
+    const p = parseTaskList(md);
+    expect(p.tasks[0]?.dqTags).toEqual(['DQ-4', 'DQ-5']);
+  });
+
+  it('parses open DQs from the preamble block only', () => {
+    const md = `# Tasks
+
+**Open DQs at time of authoring**:
+
+- **DQ-4** one
+- **DQ-5** two
+
+## Slice 0 — Test
+
+### \`[ ]\` T-01 — t
+- **Notes:** [DQ-4] inline reference, not an open DQ
+- **Verify:** ok
+`;
+    const p = parseTaskList(md);
+    expect(p.openDqs.map((d) => d.id)).toEqual(['DQ-4', 'DQ-5']);
+  });
+});
+
+describe('nextActionableTask', () => {
+  it('returns null when all tasks are done', () => {
+    const md = `## Slice 0 — Test
+### \`[x]\` T-01 — one
+- **Verify:** ok
+### \`[x]\` T-02 — two
+- **Verify:** ok
+`;
+    expect(nextActionableTask(parseTaskList(md))).toBeNull();
+  });
+
+  it('returns the first pending task when no priors block it', () => {
+    const md = `## Slice 0 — Test
+### \`[x]\` T-01 — one
+- **Verify:** ok
+### \`[ ]\` T-02 — two
+- **Verify:** ok
+### \`[ ]\` T-03 — three
+- **Verify:** ok
+`;
+    const next = nextActionableTask(parseTaskList(md));
+    expect(next?.id).toBe('T-02');
+  });
+
+  it('skips a pending task whose same-slice prior is not done', () => {
+    const md = `## Slice 0 — Test
+### \`[ ]\` T-01 — one
+- **Verify:** ok
+### \`[ ]\` T-02 — two
+- **Verify:** ok
+`;
+    // T-01 is pending with no priors → it should be next; T-02 is blocked by T-01.
+    const next = nextActionableTask(parseTaskList(md));
+    expect(next?.id).toBe('T-01');
+  });
+
+  it('does not consider cross-slice priors as blockers', () => {
+    const md = `## Slice 0 — Foundation
+### \`[ ]\` T-01 — slice 0 work
+- **Verify:** ok
+## Slice 1 — Next
+### \`[ ]\` T-02 — slice 1 work
+- **Verify:** ok
+`;
+    const parsed = parseTaskList(md);
+    // T-01 is the next actionable; T-02's same-slice priors are empty,
+    // so it would also be returned if T-01 were done. The function returns
+    // the FIRST pending in document order with satisfied same-slice priors.
+    const next = nextActionableTask(parsed);
+    expect(next?.id).toBe('T-01');
+  });
+
+  it('on the real task list, returns T-01 first', () => {
+    const next = nextActionableTask(real);
+    expect(next?.id).toBe('T-01');
+  });
+});
+
+describe('real-file structural assertions', () => {
+  it('foundation slice (slice 0) has 5 tasks: T-01..T-05', () => {
+    const slice0 = real.slices.find((s) => s.index === 0);
+    expect(slice0?.taskIds).toEqual(['T-01', 'T-02', 'T-03', 'T-04', 'T-05']);
+  });
+
+  it('slice 5 (verify & close) ends with T-47', () => {
+    const slice5 = real.slices.find((s) => s.index === 5);
+    expect(slice5?.taskIds.at(-1)).toBe('T-47');
+  });
+
+  it('slice-end smoke tasks exist (T-16, T-26, T-36, T-41)', () => {
+    for (const id of ['T-16', 'T-26', 'T-36', 'T-41']) {
+      const t = task(real, id);
+      expect(t.description.toLowerCase()).toContain('smoke');
+    }
+  });
+
+  it('T-22 (journal) carries the DQ-4 tag', () => {
+    expect(task(real, 'T-22').dqTags).toContain('DQ-4');
+  });
+
+  it('T-19 (chip catalog) carries the DQ-5 tag', () => {
+    expect(task(real, 'T-19').dqTags).toContain('DQ-5');
+  });
+});

--- a/scripts/harness/lib/task-parser.ts
+++ b/scripts/harness/lib/task-parser.ts
@@ -1,0 +1,344 @@
+/**
+ * Parses a spec-anchored task list (e.g. `docs/specs/<feature>/03-tasks.md`)
+ * into a structured form the harness controller can drive.
+ *
+ * Pure: takes a markdown string, returns a typed result. No I/O, no project
+ * imports — extraction-ready for the future spec-scaffolder tool.
+ */
+
+export type TaskStatus = 'pending' | 'in_progress' | 'done' | 'blocked';
+
+export type CitationKind =
+  | 'BR'
+  | 'NFR'
+  | 'AC'
+  | 'US'
+  | 'OQ'
+  | 'DQ'
+  | 'spec_section' // §N (with no D prefix)
+  | 'design_section'; // §DN
+
+export interface Citation {
+  kind: CitationKind;
+  /** The full reference token, e.g. 'BR-7', '§5', '§D3', 'DQ-4'. */
+  ref: string;
+}
+
+export interface Task {
+  /** e.g. 'T-01' */
+  id: string;
+  /** Numeric position in the list, useful for ordering. */
+  index: number;
+  status: TaskStatus;
+  /** Description text after the em-dash in the heading. */
+  description: string;
+  /** Slice the task belongs to (0-indexed; matches `## Slice N`). */
+  slice: number;
+  sliceName: string;
+  citations: {
+    spec: Citation[];
+    design: Citation[];
+  };
+  /** Verbatim `**What:**` body if present. */
+  what: string | null;
+  /** Verbatim `**Verify:**` body. Required by methodology — null only if malformed. */
+  verify: string | null;
+  /** Verbatim `**Notes:**` body if present. */
+  notes: string | null;
+  /** Distinct DQ tags found in `notes`, e.g. ['DQ-4']. */
+  dqTags: string[];
+}
+
+export interface OpenDQ {
+  id: string; // e.g. 'DQ-4'
+  /** Free-text body of the entry. */
+  description: string;
+}
+
+export interface SliceSummary {
+  index: number;
+  name: string;
+  taskIds: string[];
+}
+
+export interface ParsedTaskList {
+  tasks: Task[];
+  slices: SliceSummary[];
+  openDqs: OpenDQ[];
+  /** Any structural issues the parser noticed but recovered from. */
+  warnings: string[];
+}
+
+const STATUS_MAP: Record<string, TaskStatus> = {
+  ' ': 'pending',
+  '~': 'in_progress',
+  x: 'done',
+  X: 'done',
+  '!': 'blocked',
+};
+
+/** `## Slice 0 — Foundation` (em-dash or hyphen). */
+const SLICE_HEADING = /^##\s+Slice\s+(\d+)\s+[—\-–]\s+(.+?)\s*$/;
+
+/** Matches a task heading like ``### `[ ]` T-01 — TypeScript types``. */
+const TASK_HEADING = /^###\s+`\[(.)\]`\s+(T-\d+)\s+[—\-–]\s+(.+?)\s*$/;
+
+/** Open DQ list entry, e.g. `- **DQ-4** journal commit cadence — using ...`. */
+const OPEN_DQ_LINE = /^-\s+\*\*(DQ-\d+)\*\*\s+(.+?)\s*$/;
+
+/** Field bullets within a task block: `- **Cite:** ...`, `- **What:** ...`. */
+const FIELD_LINE = /^-\s+\*\*(Cite|What|Verify|Notes):\*\*\s+(.*)$/;
+
+/** Citations like `BR-7`, `NFR-1`, `AC-12`, `US-3`, `OQ-2`, `DQ-4`. */
+const TOKEN_CITATION = /\b(BR|NFR|AC|US|OQ|DQ)-(\d+)\b/g;
+
+/** Section refs: `§5` (spec) or `§D3` (design). */
+const SECTION_CITATION = /§(D?)(\d+)\b/g;
+
+/**
+ * Parses a tasks markdown file into a structured form.
+ *
+ * Tolerates extra prose between elements; ignores anything that isn't
+ * recognized as a slice heading, task heading, or field bullet.
+ */
+export function parseTaskList(markdown: string): ParsedTaskList {
+  const lines = markdown.split('\n');
+  const warnings: string[] = [];
+  const tasks: Task[] = [];
+  const slices: SliceSummary[] = [];
+  const openDqs: OpenDQ[] = [];
+
+  let currentSliceIndex = -1;
+  let currentSliceName = '';
+  let inOpenDqsBlock = false;
+  let taskCounter = 0;
+
+  // Per-task accumulators
+  let pendingTask: Task | null = null;
+  let pendingFieldName: 'cite' | 'what' | 'verify' | 'notes' | null = null;
+  let pendingFieldBuffer: string[] = [];
+
+  function flushField(): void {
+    if (!pendingTask || !pendingFieldName) return;
+    const value = pendingFieldBuffer.join('\n').trim();
+    if (!value) {
+      pendingFieldName = null;
+      pendingFieldBuffer = [];
+      return;
+    }
+    switch (pendingFieldName) {
+      case 'cite':
+        pendingTask.citations = parseCitations(value);
+        break;
+      case 'what':
+        pendingTask.what = value;
+        break;
+      case 'verify':
+        pendingTask.verify = value;
+        break;
+      case 'notes':
+        pendingTask.notes = value;
+        pendingTask.dqTags = extractDqTags(value);
+        break;
+    }
+    pendingFieldName = null;
+    pendingFieldBuffer = [];
+  }
+
+  function flushTask(): void {
+    flushField();
+    if (!pendingTask) return;
+    if (!pendingTask.verify) {
+      warnings.push(`${pendingTask.id} has no Verify line.`);
+    }
+    tasks.push(pendingTask);
+    const slice = slices[slices.length - 1];
+    if (slice && slice.index === pendingTask.slice) {
+      slice.taskIds.push(pendingTask.id);
+    }
+    pendingTask = null;
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+
+    // Open DQs block — bounded by the heading and the next blank line / heading.
+    if (/Open DQs at time of authoring/i.test(line)) {
+      inOpenDqsBlock = true;
+      continue;
+    }
+    if (inOpenDqsBlock) {
+      const match = OPEN_DQ_LINE.exec(line);
+      if (match) {
+        openDqs.push({ id: match[1], description: match[2] });
+        continue;
+      }
+      // Exit the block on a non-list-item, non-blank line.
+      if (line.trim() && !line.startsWith('-')) {
+        inOpenDqsBlock = false;
+      }
+      // Continue past blank lines so we keep collecting list items.
+    }
+
+    // Slice heading
+    const sliceMatch = SLICE_HEADING.exec(line);
+    if (sliceMatch) {
+      flushTask();
+      currentSliceIndex = parseInt(sliceMatch[1]!, 10);
+      currentSliceName = sliceMatch[2]!;
+      slices.push({
+        index: currentSliceIndex,
+        name: currentSliceName,
+        taskIds: [],
+      });
+      continue;
+    }
+
+    // Task heading
+    const taskMatch = TASK_HEADING.exec(line);
+    if (taskMatch) {
+      flushTask();
+      const statusChar = taskMatch[1]!;
+      const id = taskMatch[2]!;
+      const description = taskMatch[3]!;
+      const status = STATUS_MAP[statusChar];
+      if (!status) {
+        warnings.push(`${id} has unrecognized status marker '${statusChar}'.`);
+      }
+      if (currentSliceIndex < 0) {
+        warnings.push(`${id} appears before any slice heading.`);
+      }
+      pendingTask = {
+        id,
+        index: taskCounter++,
+        status: status ?? 'pending',
+        description,
+        slice: currentSliceIndex,
+        sliceName: currentSliceName,
+        citations: { spec: [], design: [] },
+        what: null,
+        verify: null,
+        notes: null,
+        dqTags: [],
+      };
+      continue;
+    }
+
+    if (!pendingTask) continue;
+
+    // Field bullet within the current task block
+    const fieldMatch = FIELD_LINE.exec(line);
+    if (fieldMatch) {
+      flushField();
+      const name = fieldMatch[1]!.toLowerCase() as
+        | 'cite'
+        | 'what'
+        | 'verify'
+        | 'notes';
+      pendingFieldName = name;
+      pendingFieldBuffer = [fieldMatch[2] ?? ''];
+      continue;
+    }
+
+    // Continuation of the current field (indented or wrapped lines)
+    if (pendingFieldName) {
+      pendingFieldBuffer.push(line);
+    }
+  }
+
+  // EOF flush
+  flushTask();
+
+  return { tasks, slices, openDqs, warnings };
+}
+
+/**
+ * Splits a citation line on `;` to separate the spec side from the design side.
+ * Convention from the methodology: `Cite: spec ...; design ...` (order may vary).
+ */
+function parseCitations(line: string): {
+  spec: Citation[];
+  design: Citation[];
+} {
+  const segments = line.split(';').map((s) => s.trim());
+  const spec: Citation[] = [];
+  const design: Citation[] = [];
+
+  for (const segment of segments) {
+    const lower = segment.toLowerCase();
+    const isSpecSegment = lower.startsWith('spec');
+    const isDesignSegment = lower.startsWith('design');
+    const target = isDesignSegment ? design : spec;
+
+    // If the segment doesn't explicitly say spec/design, fall back to context:
+    // sections starting with §D go to design, otherwise spec.
+    const explicit = isSpecSegment || isDesignSegment;
+
+    // Token citations (BR-N, AC-N, etc.)
+    for (const m of segment.matchAll(TOKEN_CITATION)) {
+      const kind = m[1] as CitationKind;
+      target.push({ kind, ref: `${m[1]}-${m[2]}` });
+    }
+
+    // Section citations (§N or §DN)
+    for (const m of segment.matchAll(SECTION_CITATION)) {
+      const isDesign = m[1] === 'D';
+      const ref = `§${m[1]}${m[2]}`;
+      const dest = explicit ? target : isDesign ? design : spec;
+      dest.push({
+        kind: isDesign ? 'design_section' : 'spec_section',
+        ref,
+      });
+    }
+  }
+
+  return {
+    spec: dedupeCitations(spec),
+    design: dedupeCitations(design),
+  };
+}
+
+function dedupeCitations(items: Citation[]): Citation[] {
+  const seen = new Set<string>();
+  const out: Citation[] = [];
+  for (const c of items) {
+    const key = `${c.kind}:${c.ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c);
+  }
+  return out;
+}
+
+function extractDqTags(text: string): string[] {
+  const tags = new Set<string>();
+  // Match `[DQ-4]` bracketed form (canonical) and bare `DQ-4` for tolerance.
+  const bracketed = /\[(DQ-\d+)\]/g;
+  for (const m of text.matchAll(bracketed)) tags.add(m[1]!);
+  // Also catch bare DQ refs in notes that the methodology would accept.
+  const bare = /\b(DQ-\d+)\b/g;
+  for (const m of text.matchAll(bare)) tags.add(m[1]!);
+  return Array.from(tags).sort();
+}
+
+/**
+ * Returns the next task that is `pending` AND whose prior tasks in the same
+ * slice are all `done`. Cross-slice ordering is NOT enforced here — the
+ * controller's slice gate handles that.
+ */
+export function nextActionableTask(parsed: ParsedTaskList): Task | null {
+  for (let i = 0; i < parsed.tasks.length; i++) {
+    const task = parsed.tasks[i]!;
+    if (task.status !== 'pending') continue;
+
+    const priorInSlice = parsed.tasks
+      .slice(0, i)
+      .filter((t) => t.slice === task.slice);
+
+    const blocked = priorInSlice.some((t) => t.status !== 'done');
+    if (blocked) continue;
+
+    return task;
+  }
+  return null;
+}

--- a/scripts/harness/tsconfig.json
+++ b/scripts/harness/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.tmp/tsconfig.harness.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+
+    "types": ["node", "vitest/globals"],
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./scripts/harness/tsconfig.json"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
## Summary

First commit of the agentic harness for Phase 5 (build cycles). Per the architecture plan at \`~/.claude/plans/i-want-to-explore-compressed-shannon.md\`, this is MVP step 1 — pure parsing, no LLM calls, no controller orchestration yet.

The parser turns a spec-anchored task list (e.g. \`docs/specs/incident-capture/03-tasks.md\`) into typed \`Task[]\` with citations, slice membership, status, and DQ tags. Plus \`nextActionableTask()\` — the function the controller will call each iteration to pick the next task to dispatch.

## Why it's in \`scripts/harness/lib/\`

- Pure module with no dog-log imports, so it can be lifted into the future spec-scaffolder tool with no modification (per plan §6 integration notes).
- New \`scripts/harness/tsconfig.json\` is referenced from the root tsconfig so \`tsc -b\` covers it. Strict, Node ESM.

## Tests

31 tests, all green:

- 12 against the **real** \`docs/specs/incident-capture/03-tasks.md\` (47 tasks, 6 slices, 3 open DQs) — confirms the parser matches the artifact format we just produced.
- 14 against targeted fixtures (status markers, malformed cite lines, reversed citation order, deduplication, DQ tag formats, open-DQ block scoping).
- 5 structural assertions on the real file (foundation slice composition, slice-end smoke task naming, DQ-tag propagation).

\`pnpm exec tsc -b\` passes; \`pnpm run test:unit\` passes (636 tests; harness tests included).

## One finding surfaced

Three slice-5 tasks (T-43 coverage check, T-46 status flip, T-47 follow-up agent) cite process docs (\`CLAUDE.md\`, "plan Phase 6") rather than spec/design sections. Test relaxed to slices 0–4. The future citation-linter will need the same carve-out — captured as a known limitation in the parser doc.

## Test plan

- [ ] Confirm \`pnpm exec tsc -b\` is green
- [ ] Confirm \`pnpm exec vitest run scripts/harness/lib/task-parser.test.ts\` is green
- [ ] Confirm \`pnpm run test:unit\` is green
- [ ] Eyeball \`scripts/harness/lib/task-parser.ts\` for the \`Task\` shape — this becomes the input contract for the builder agent

## What's next (per plan §8)

MVP step 2: \`controller.ts\` skeleton (read-only — read tasks, find next, print it; no agent dispatch yet). Then citation linter as a Husky \`commit-msg\` hook. Then builder agent.