### PR TITLE
feat(harness): MVP step 3 — citation-linter + commit-msg hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm exec tsx scripts/harness/cli.ts lint-commit "$1"

--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -24,6 +24,7 @@ import {
   type SliceProgress,
   type StatusSummary,
 } from './lib/controller.ts';
+import { lintCommitMessage } from './lib/citation-linter.ts';
 
 const DEFAULT_TASK_FILE = 'docs/specs/incident-capture/03-tasks.md';
 
@@ -32,13 +33,15 @@ function usage(): string {
     'Usage: harness <command> [options]',
     '',
     'Commands:',
-    '  next              Print the next actionable task and slice context.',
-    '  status            Print progress per slice plus open DQs.',
+    '  next                       Print the next actionable task and slice context.',
+    '  status                     Print progress per slice plus open DQs.',
+    '  lint-commit <file>         Validate a commit-message file against the',
+    '                             citation rule. Exits non-zero if invalid.',
     '',
     'Options:',
-    `  --file <path>     Task list to read (default: ${DEFAULT_TASK_FILE}).`,
-    '  --json            Emit JSON instead of human-readable text.',
-    '  -h, --help        Show this help.',
+    `  --file <path>              Task list to read (default: ${DEFAULT_TASK_FILE}).`,
+    '  --json                     Emit JSON instead of human-readable text.',
+    '  -h, --help                 Show this help.',
   ].join('\n');
 }
 
@@ -208,6 +211,33 @@ function main(): void {
         printNextHuman(fileArg, next);
       }
       process.exit(next.warnings.length === 0 ? 0 : 2);
+      break;
+    }
+    case 'lint-commit': {
+      const msgFile = positionals[1];
+      if (!msgFile) {
+        fail('lint-commit requires a commit-message file path\n\n' + usage());
+      }
+      const msgPath = resolve(process.cwd(), msgFile);
+      let raw: string;
+      try {
+        raw = readFileSync(msgPath, 'utf8');
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        fail(`could not read commit-message file '${msgFile}': ${reason}`);
+      }
+      const result = lintCommitMessage(raw);
+      if (values.json) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      } else if (result.valid) {
+        const note = result.exemptReason
+          ? `exempt (${result.exemptReason})`
+          : `cites: ${result.citations.join(', ')}`;
+        process.stdout.write(`harness: commit OK — ${note}\n`);
+      } else {
+        process.stderr.write(`harness: ${result.failureReason}\n`);
+      }
+      process.exit(result.valid ? 0 : 1);
       break;
     }
     default:

--- a/scripts/harness/lib/citation-linter.test.ts
+++ b/scripts/harness/lib/citation-linter.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CONFIG, lintCommitMessage } from './citation-linter';
+
+describe('lintCommitMessage — happy paths', () => {
+  it('accepts a typed BR citation', () => {
+    const r = lintCommitMessage('feat(incidents): add timer (BR-3)');
+    expect(r.valid).toBe(true);
+    expect(r.citations).toEqual(['BR-3']);
+    expect(r.exemptReason).toBeNull();
+  });
+
+  it('accepts a typed AC citation', () => {
+    const r = lintCommitMessage('test(incidents): cover AC-12');
+    expect(r.valid).toBe(true);
+    expect(r.citations).toEqual(['AC-12']);
+  });
+
+  it('accepts a §N section citation', () => {
+    const r = lintCommitMessage('feat(incidents): types per §5');
+    expect(r.valid).toBe(true);
+    expect(r.citations).toEqual(['§5']);
+  });
+
+  it('accepts a §DN design section citation', () => {
+    const r = lintCommitMessage('feat(incidents): wire ActivationFab per §D2');
+    expect(r.valid).toBe(true);
+    expect(r.citations).toEqual(['§D2']);
+  });
+
+  it('accepts a T-N task citation (process-task carve-out)', () => {
+    const r = lintCommitMessage('docs(spec): mark T-46 status flip to shipped');
+    expect(r.valid).toBe(true);
+    expect(r.citations).toEqual(['T-46']);
+  });
+
+  it('extracts multiple distinct citations and dedupes', () => {
+    const r = lintCommitMessage(
+      'feat(incidents): timer + STOP\n\nImplements BR-2, BR-3, BR-3, AC-1; design §D8.'
+    );
+    expect(r.valid).toBe(true);
+    expect(r.citations).toEqual(['AC-1', 'BR-2', 'BR-3', '§D8']);
+  });
+});
+
+describe('lintCommitMessage — exemptions', () => {
+  it('exempts merge commits', () => {
+    const r = lintCommitMessage("Merge branch 'main' into feat/x");
+    expect(r.valid).toBe(true);
+    expect(r.exemptReason).toBe('merge commit');
+  });
+
+  it('exempts revert commits', () => {
+    const r = lintCommitMessage(
+      'Revert "feat(incidents): timer (BR-3) (#999)"'
+    );
+    expect(r.valid).toBe(true);
+    expect(r.exemptReason).toBe('revert commit');
+  });
+
+  it('exempts chore type by default', () => {
+    const r = lintCommitMessage('chore(deps): bump react to 19.2');
+    expect(r.valid).toBe(true);
+    expect(r.exemptReason).toBe("exempt commit type 'chore'");
+  });
+
+  it('exempts ci type by default', () => {
+    const r = lintCommitMessage('ci: cache pnpm store');
+    expect(r.valid).toBe(true);
+    expect(r.exemptReason).toBe("exempt commit type 'ci'");
+  });
+
+  it('exempts harness scope by default', () => {
+    const r = lintCommitMessage('feat(harness): add citation linter');
+    expect(r.valid).toBe(true);
+    expect(r.exemptReason).toBe("exempt commit scope 'harness'");
+  });
+
+  it('exempts via [skip-cite] token in body', () => {
+    const r = lintCommitMessage(
+      'feat(incidents): one-off prototype\n\n[skip-cite] reason: spike to test something'
+    );
+    expect(r.valid).toBe(true);
+    expect(r.exemptReason).toBe("contains '[skip-cite]' token");
+  });
+
+  it('does NOT exempt fix(incidents) — needs a citation', () => {
+    const r = lintCommitMessage('fix(incidents): off-by-one in timer');
+    expect(r.valid).toBe(false);
+    expect(r.failureReason).toContain('no spec-anchored citation');
+  });
+
+  it('does NOT exempt scopes that look like exempt types (e.g. feat(chore))', () => {
+    const r = lintCommitMessage('feat(chore): not actually a chore');
+    // 'feat' is not exempt, scope 'chore' is not in exemptScopes by default.
+    expect(r.valid).toBe(false);
+  });
+
+  it('respects custom exempt scopes', () => {
+    const r = lintCommitMessage('feat(infra): provision dev firestore', {
+      ...DEFAULT_CONFIG,
+      exemptScopes: ['harness', 'infra'],
+    });
+    expect(r.valid).toBe(true);
+    expect(r.exemptReason).toBe("exempt commit scope 'infra'");
+  });
+});
+
+describe('lintCommitMessage — failure modes', () => {
+  it('rejects an empty message', () => {
+    const r = lintCommitMessage('');
+    expect(r.valid).toBe(false);
+    expect(r.failureReason).toBe('commit message is empty');
+  });
+
+  it('rejects a message with only comment lines', () => {
+    const r = lintCommitMessage(
+      '# Please enter the commit message...\n# Lines starting with # are ignored.'
+    );
+    expect(r.valid).toBe(false);
+    expect(r.failureReason).toBe('commit message is empty');
+  });
+
+  it('rejects feat without any citation', () => {
+    const r = lintCommitMessage('feat(incidents): add severity chips');
+    expect(r.valid).toBe(false);
+    expect(r.failureReason).toContain('no spec-anchored citation');
+    expect(r.failureReason).toContain('Acceptable citation forms');
+  });
+
+  it('rejects refactor without citation', () => {
+    const r = lintCommitMessage('refactor(incidents): split surface from page');
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects when only a PR-style ref like (#152) is present', () => {
+    const r = lintCommitMessage('feat(incidents): timer (#152)');
+    expect(r.valid).toBe(false);
+  });
+
+  it("does not match 'BR-' or 'AC-' without a number", () => {
+    const r = lintCommitMessage('feat(incidents): generic BR- and AC- refs');
+    expect(r.valid).toBe(false);
+  });
+});
+
+describe('lintCommitMessage — comment stripping & subject parsing', () => {
+  it('uses the first non-comment line as the subject', () => {
+    const msg = [
+      '# please enter your commit message',
+      '',
+      'feat(incidents): wire timer (BR-3)',
+      '',
+      '# everything below the dashed line is ignored',
+    ].join('\n');
+    const r = lintCommitMessage(msg);
+    expect(r.subject).toBe('feat(incidents): wire timer (BR-3)');
+    expect(r.valid).toBe(true);
+  });
+
+  it('does NOT strip non-leading # (so #issue-12 in body still counts as text)', () => {
+    const msg = 'feat(incidents): wire timer (BR-3)\n\nFixes #issue-12';
+    const r = lintCommitMessage(msg);
+    expect(r.valid).toBe(true);
+    expect(r.subject).toBe('feat(incidents): wire timer (BR-3)');
+  });
+});

--- a/scripts/harness/lib/citation-linter.test.ts
+++ b/scripts/harness/lib/citation-linter.test.ts
@@ -75,12 +75,23 @@ describe('lintCommitMessage — exemptions', () => {
     expect(r.exemptReason).toBe("exempt commit scope 'harness'");
   });
 
-  it('exempts via [skip-cite] token in body', () => {
+  it('exempts via [skip-cite] marker at the start of a line', () => {
     const r = lintCommitMessage(
-      'feat(incidents): one-off prototype\n\n[skip-cite] reason: spike to test something'
+      'feat(incidents): one-off prototype\n\n[skip-cite] spike to test something'
     );
     expect(r.valid).toBe(true);
-    expect(r.exemptReason).toBe("contains '[skip-cite]' token");
+    expect(r.exemptReason).toContain('[skip-cite]');
+  });
+
+  it('does NOT exempt via [skip-cite] when it appears mid-line (regression)', () => {
+    // A commit message that *documents* the [skip-cite] token shouldn't
+    // accidentally exempt itself. This was a real bug found in dogfooding
+    // round 12 — the linter's own help text mentioned the token, and that
+    // text in a commit-message body matched the exemption.
+    const r = lintCommitMessage(
+      'feat(incidents): add new feature\n\nDocs note: see [skip-cite] in the help.'
+    );
+    expect(r.valid).toBe(false);
   });
 
   it('does NOT exempt fix(incidents) — needs a citation', () => {

--- a/scripts/harness/lib/citation-linter.ts
+++ b/scripts/harness/lib/citation-linter.ts
@@ -48,7 +48,12 @@ export interface LintResult {
 
 const MERGE_RE = /^Merge\s/;
 const REVERT_RE = /^Revert\s/;
-const SKIP_TOKEN = '[skip-cite]';
+/**
+ * Anchored to the start of a line so it cannot match inside documentation
+ * or quoted help text. Optional `:reason` suffix is recorded only as a
+ * convention; not required for the match.
+ */
+const SKIP_TOKEN_RE = /^\[skip-cite(?::[^\]]*)?]/m;
 
 /** Conventional-commit prefix: `type(scope)?(!)?: subject`. Captures type, scope. */
 const CC_PREFIX = /^(?<type>[a-zA-Z]+)(?:\((?<scope>[^)]+)\))?!?:\s/;
@@ -76,17 +81,6 @@ export function lintCommitMessage(
       .split('\n')
       .map((line) => line.trim())
       .find((line) => line.length > 0) ?? null;
-
-  // Skip token short-circuit — power-user escape hatch.
-  if (cleaned.includes(SKIP_TOKEN)) {
-    return {
-      valid: true,
-      citations: extractCitations(cleaned),
-      subject,
-      exemptReason: `contains '${SKIP_TOKEN}' token`,
-      failureReason: null,
-    };
-  }
 
   if (subject === null) {
     return {
@@ -142,6 +136,19 @@ export function lintCommitMessage(
     };
   }
 
+  // Power-user escape hatch — checked AFTER scope/type so that legitimate
+  // exempt commits get the right reason, AND anchored to the start of a line
+  // so it cannot match inside documentation or quoted help text.
+  if (SKIP_TOKEN_RE.test(cleaned)) {
+    return {
+      valid: true,
+      citations: extractCitations(cleaned),
+      subject,
+      exemptReason: "contains '[skip-cite]' marker (start of line)",
+      failureReason: null,
+    };
+  }
+
   const citations = extractCitations(cleaned);
   if (citations.length === 0) {
     return {
@@ -186,6 +193,6 @@ function buildFailureReason(
     `If this commit doesn't trace to a spec section, you can:`,
     `  - Use an exempt type:      ${typesList}`,
     `  - Use an exempt scope:     ${scopesList}`,
-    `  - Add a [skip-cite] token anywhere in the message`,
+    `  - Start a line with the [skip-cite] marker`,
   ].join('\n');
 }

--- a/scripts/harness/lib/citation-linter.ts
+++ b/scripts/harness/lib/citation-linter.ts
@@ -1,0 +1,191 @@
+/**
+ * Validates that a git commit message cites at least one spec-anchored
+ * reference, OR is explicitly exempt.
+ *
+ * Methodology rule (from the architecture plan §1):
+ *   "regex over commit message must match (BR|NFR|AC|US)-\\d+|§\\d+|§D\\d+.
+ *    Hard fail if absent."
+ *
+ * In practice we accept a slightly broader set:
+ *   - typed refs:     BR-N, NFR-N, AC-N, US-N, OQ-N, DQ-N
+ *   - section refs:   §N (spec) and §DN (design)
+ *   - task refs:      T-N — for process tasks (T-43/46/47 cite docs not §)
+ *
+ * Exempt commit subjects:
+ *   - merge subjects     ("Merge ...")
+ *   - revert subjects    ("Revert ...")
+ *   - configurable type  prefixes (default: chore, style, ci, build)
+ *   - configurable scope prefixes (default: harness — tooling itself)
+ *   - any commit containing the token [skip-cite] anywhere in its body
+ *
+ * Pure: takes a string, returns a typed result. No I/O. No project imports.
+ * Extraction-ready for the future spec-scaffolder tool.
+ */
+
+export interface CitationLinterConfig {
+  /** Conventional-commit types whose commits skip the citation rule. */
+  exemptTypes: string[];
+  /** Conventional-commit scopes whose commits skip the citation rule. */
+  exemptScopes: string[];
+}
+
+export const DEFAULT_CONFIG: CitationLinterConfig = {
+  exemptTypes: ['chore', 'style', 'ci', 'build'],
+  exemptScopes: ['harness'],
+};
+
+export interface LintResult {
+  valid: boolean;
+  /** Distinct citation tokens found in the message (subject + body). */
+  citations: string[];
+  /** Subject line as parsed (first non-empty, non-comment line). */
+  subject: string | null;
+  /** Set when the message is exempt from the citation rule; explains why. */
+  exemptReason: string | null;
+  /** Set when the message is invalid; explains how to fix. */
+  failureReason: string | null;
+}
+
+const MERGE_RE = /^Merge\s/;
+const REVERT_RE = /^Revert\s/;
+const SKIP_TOKEN = '[skip-cite]';
+
+/** Conventional-commit prefix: `type(scope)?(!)?: subject`. Captures type, scope. */
+const CC_PREFIX = /^(?<type>[a-zA-Z]+)(?:\((?<scope>[^)]+)\))?!?:\s/;
+
+const TYPED_CITATION = /\b(?:BR|NFR|AC|US|OQ|DQ|T)-\d+\b/g;
+const SECTION_CITATION = /§D?\d+\b/g;
+
+/**
+ * Lints a full commit message string.
+ *
+ * Treats lines starting with `#` as git editor comments and ignores them.
+ * The "subject" is the first non-empty, non-comment line.
+ */
+export function lintCommitMessage(
+  raw: string,
+  config: CitationLinterConfig = DEFAULT_CONFIG
+): LintResult {
+  const cleaned = raw
+    .split('\n')
+    .filter((line) => !line.startsWith('#'))
+    .join('\n');
+
+  const subject =
+    cleaned
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? null;
+
+  // Skip token short-circuit — power-user escape hatch.
+  if (cleaned.includes(SKIP_TOKEN)) {
+    return {
+      valid: true,
+      citations: extractCitations(cleaned),
+      subject,
+      exemptReason: `contains '${SKIP_TOKEN}' token`,
+      failureReason: null,
+    };
+  }
+
+  if (subject === null) {
+    return {
+      valid: false,
+      citations: [],
+      subject: null,
+      exemptReason: null,
+      failureReason: 'commit message is empty',
+    };
+  }
+
+  if (MERGE_RE.test(subject)) {
+    return {
+      valid: true,
+      citations: extractCitations(cleaned),
+      subject,
+      exemptReason: 'merge commit',
+      failureReason: null,
+    };
+  }
+
+  if (REVERT_RE.test(subject)) {
+    return {
+      valid: true,
+      citations: extractCitations(cleaned),
+      subject,
+      exemptReason: 'revert commit',
+      failureReason: null,
+    };
+  }
+
+  const cc = CC_PREFIX.exec(subject)?.groups ?? {};
+  const type = cc['type']?.toLowerCase();
+  const scope = cc['scope']?.toLowerCase();
+
+  if (type && config.exemptTypes.includes(type)) {
+    return {
+      valid: true,
+      citations: extractCitations(cleaned),
+      subject,
+      exemptReason: `exempt commit type '${type}'`,
+      failureReason: null,
+    };
+  }
+
+  if (scope && config.exemptScopes.includes(scope)) {
+    return {
+      valid: true,
+      citations: extractCitations(cleaned),
+      subject,
+      exemptReason: `exempt commit scope '${scope}'`,
+      failureReason: null,
+    };
+  }
+
+  const citations = extractCitations(cleaned);
+  if (citations.length === 0) {
+    return {
+      valid: false,
+      citations: [],
+      subject,
+      exemptReason: null,
+      failureReason: buildFailureReason(subject, config),
+    };
+  }
+
+  return {
+    valid: true,
+    citations,
+    subject,
+    exemptReason: null,
+    failureReason: null,
+  };
+}
+
+function extractCitations(message: string): string[] {
+  const found = new Set<string>();
+  for (const m of message.matchAll(TYPED_CITATION)) found.add(m[0]);
+  for (const m of message.matchAll(SECTION_CITATION)) found.add(m[0]);
+  return Array.from(found).sort();
+}
+
+function buildFailureReason(
+  subject: string,
+  config: CitationLinterConfig
+): string {
+  const typesList = config.exemptTypes.join(', ');
+  const scopesList = config.exemptScopes.join(', ');
+  return [
+    `no spec-anchored citation found in commit message`,
+    `subject: ${subject}`,
+    ``,
+    `Acceptable citation forms (any one):`,
+    `  - Typed refs:    BR-N, NFR-N, AC-N, US-N, OQ-N, DQ-N, T-N`,
+    `  - Sections:      §N (spec), §DN (design)`,
+    ``,
+    `If this commit doesn't trace to a spec section, you can:`,
+    `  - Use an exempt type:      ${typesList}`,
+    `  - Use an exempt scope:     ${scopesList}`,
+    `  - Add a [skip-cite] token anywhere in the message`,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

Per the architecture plan §1, every commit on spec-anchored work must cite a BR/NFR/AC/US/OQ/DQ/§/T-N reference, OR be explicitly exempt. This PR ships the linter as a pure function plus a Husky \`commit-msg\` hook that fires on every commit.

## Two commits

1. **\`7cb9e29\` feat(harness): add citation-linter + commit-msg hook (MVP step 3)** — the linter, hook, CLI command, 23 unit tests.
2. **\`f95866e\` fix(harness): anchor [skip-cite] marker to start-of-line** — bug found immediately on round-12 dogfooding (commit #1 was reported as exempt via [skip-cite] because the linter's *help text* mentioned the token in commit body). Fix: anchor to start-of-line; reorder so scope/type exemptions take precedence.

## Citation grammar

Broader than the plan's strict regex to accommodate real cases the methodology surfaced (T-43/46/47 process tasks):

- **Typed refs:** \`BR-N\`, \`NFR-N\`, \`AC-N\`, \`US-N\`, \`OQ-N\`, \`DQ-N\`
- **Sections:** \`§N\` (spec), \`§DN\` (design)
- **Task refs:** \`T-N\`

## Exemptions (configurable; defaults baked in)

- Conventional-commit **types**: \`chore\`, \`style\`, \`ci\`, \`build\`
- Conventional-commit **scopes**: \`harness\` (tooling itself)
- Subject prefix: \`Merge \`, \`Revert \`
- Start-of-line \`[skip-cite]\` marker (escape hatch — must be at the start of a line)

## Verify

- \`pnpm exec tsc -b\`: ✓
- \`pnpm run test:unit\`: 673 passing
- \`pnpm run lint\`: clean
- \`pnpm run test:coverage\`: green (pre-push hook passes; flaky on first run, retried clean)
- Direct hook invocation: \`/.husky/commit-msg /path/to/file\` — exits 1 for no-citation, 0 for cited or exempt
- Both commits in this PR landed via the \`harness\` scope exemption — end-to-end dogfooding

## Real bug caught by dogfooding (now fixed)

Round 12 (round-by-round dogfooding) caught the [skip-cite] false-positive within the first commit message. This is exactly the kind of finding the methodology's "use the tool on the tool" pattern is designed to surface — and it's a strong argument for the upcoming cold-reader having an eval suite that includes self-reference cases.

## What's next

MVP step 4: builder agent. Hand-driven on T-01 first to characterize how the cited-context gets formatted for the prompt, before automating dispatch.