### PR TITLE
feat(harness): MVP step 4 — builder agent prompt + context-prep

### DIFF
--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -25,8 +25,15 @@ import {
   type StatusSummary,
 } from './lib/controller.ts';
 import { lintCommitMessage } from './lib/citation-linter.ts';
+import {
+  buildBuilderInput,
+  formatBuilderInputMarkdown,
+} from './lib/builder-input.ts';
+import { parseTaskList } from './lib/task-parser.ts';
+import { dirname, join } from 'node:path';
 
 const DEFAULT_TASK_FILE = 'docs/specs/incident-capture/03-tasks.md';
+const BUILDER_PROMPT_PATH = 'scripts/harness/lib/prompts/builder.md';
 
 function usage(): string {
   return [
@@ -37,10 +44,14 @@ function usage(): string {
     '  status                     Print progress per slice plus open DQs.',
     '  lint-commit <file>         Validate a commit-message file against the',
     '                             citation rule. Exits non-zero if invalid.',
+    '  prepare <task-id>          Render the system prompt + per-task input for',
+    '                             the builder agent. Use this to hand-drive a',
+    '                             single task in a fresh Claude Code session.',
     '',
     'Options:',
     `  --file <path>              Task list to read (default: ${DEFAULT_TASK_FILE}).`,
     '  --json                     Emit JSON instead of human-readable text.',
+    '  --no-system-prompt         Render only the per-task input (omit builder.md).',
     '  -h, --help                 Show this help.',
   ].join('\n');
 }
@@ -170,6 +181,7 @@ function main(): void {
       file: { type: 'string' },
       json: { type: 'boolean', default: false },
       help: { type: 'boolean', short: 'h', default: false },
+      'no-system-prompt': { type: 'boolean', default: false },
     },
     allowPositionals: true,
   });
@@ -238,6 +250,71 @@ function main(): void {
         process.stderr.write(`harness: ${result.failureReason}\n`);
       }
       process.exit(result.valid ? 0 : 1);
+      break;
+    }
+    case 'prepare': {
+      const taskId = positionals[1];
+      if (!taskId) {
+        fail('prepare requires a task id (e.g. T-01)\n\n' + usage());
+      }
+      const tasksMd = readTaskFile(filePath);
+      const parsed = parseTaskList(tasksMd);
+      const task = parsed.tasks.find((t) => t.id === taskId);
+      if (!task) {
+        fail(`task ${taskId} not found in ${fileArg}`);
+      }
+
+      // Discover spec/design files as siblings of the task file. The methodology
+      // convention is `<feature>/00-brief.md`, `01-spec.md`, `02-design.md`,
+      // `03-tasks.md`. If the convention isn't followed, the user can override
+      // by piping their own input — but for now we assume convention.
+      const featureDir = dirname(filePath);
+      const specPath = join(featureDir, '01-spec.md');
+      const designPath = join(featureDir, '02-design.md');
+      let specMd: string;
+      let designMd: string;
+      try {
+        specMd = readFileSync(specPath, 'utf8');
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        fail(`could not read spec file '${specPath}': ${reason}`);
+      }
+      try {
+        designMd = readFileSync(designPath, 'utf8');
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        fail(`could not read design file '${designPath}': ${reason}`);
+      }
+
+      const input = buildBuilderInput({
+        task,
+        specMarkdown: specMd,
+        designMarkdown: designMd,
+      });
+
+      if (values.json) {
+        process.stdout.write(`${JSON.stringify(input, null, 2)}\n`);
+        process.exit(input.missing_citations.length === 0 ? 0 : 2);
+      }
+
+      // Default human form: builder system prompt + per-task input markdown,
+      // ready to paste into a fresh Claude Code session.
+      if (!values['no-system-prompt']) {
+        const promptPath = resolve(process.cwd(), BUILDER_PROMPT_PATH);
+        try {
+          const systemPrompt = readFileSync(promptPath, 'utf8');
+          process.stdout.write(systemPrompt);
+          process.stdout.write('\n---\n\n');
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          fail(
+            `could not read builder prompt '${BUILDER_PROMPT_PATH}': ${reason}`
+          );
+        }
+      }
+      process.stdout.write(formatBuilderInputMarkdown(input));
+      process.stdout.write('\n');
+      process.exit(input.missing_citations.length === 0 ? 0 : 2);
       break;
     }
     default:

--- a/scripts/harness/lib/builder-input.test.ts
+++ b/scripts/harness/lib/builder-input.test.ts
@@ -1,0 +1,196 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildBuilderInput, formatBuilderInputMarkdown } from './builder-input';
+import { parseTaskList, type Task } from './task-parser';
+
+const root = resolve(__dirname, '../../../docs/specs/incident-capture');
+const tasksMd = readFileSync(`${root}/03-tasks.md`, 'utf8');
+const specMd = readFileSync(`${root}/01-spec.md`, 'utf8');
+const designMd = readFileSync(`${root}/02-design.md`, 'utf8');
+const parsed = parseTaskList(tasksMd);
+
+function task(id: string): Task {
+  const t = parsed.tasks.find((x) => x.id === id);
+  if (!t) throw new Error(`task ${id} not found`);
+  return t;
+}
+
+describe('buildBuilderInput — T-01 (foundation, smallest surface)', () => {
+  const input = buildBuilderInput({
+    task: task('T-01'),
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+  });
+
+  it('carries the task id and description', () => {
+    expect(input.task_id).toBe('T-01');
+    expect(input.description).toMatch(/TypeScript types/);
+  });
+
+  it('extracts spec §5 and design §D3 (T-01s only citations)', () => {
+    const refs = input.citations.map((c) => c.ref);
+    expect(refs).toEqual(['§5', '§D3']);
+  });
+
+  it('cited bodies contain the expected markers from the source', () => {
+    const spec5 = input.citations.find((c) => c.ref === '§5')!;
+    expect(spec5.source).toBe('spec');
+    expect(spec5.body).toMatch(/^## §5 Data Model/);
+
+    const designD3 = input.citations.find((c) => c.ref === '§D3')!;
+    expect(designD3.source).toBe('design');
+    expect(designD3.body).toMatch(/^## §D3 Data Model/);
+    expect(designD3.body).toMatch(/interface Incident/);
+  });
+
+  it('passes through the Verify line and absence of notes', () => {
+    expect(input.verify).toMatch(/tsc -b/);
+    expect(input.notes).toBeNull();
+    expect(input.dq_tags).toEqual([]);
+  });
+
+  it('reports zero missing citations for T-01', () => {
+    expect(input.missing_citations).toEqual([]);
+  });
+
+  it('defaults context_files to CLAUDE.md', () => {
+    expect(input.context_files).toEqual(['CLAUDE.md']);
+  });
+
+  it('uses DEFAULT_BUDGET when none supplied', () => {
+    expect(input.budget.tokens).toBeGreaterThan(0);
+    expect(input.budget.wallClockMinutes).toBeGreaterThan(0);
+    expect(input.budget.retries).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('buildBuilderInput — T-17 (mid-event editing, multiple BR cites)', () => {
+  const input = buildBuilderInput({
+    task: task('T-17'),
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+  });
+
+  it('extracts every BR citation as a separate entry', () => {
+    const brRefs = input.citations
+      .filter((c) => c.ref.startsWith('BR-'))
+      .map((c) => c.ref);
+    expect(brRefs).toEqual(
+      expect.arrayContaining(['BR-6', 'BR-7', 'BR-8', 'BR-9', 'BR-19', 'BR-22'])
+    );
+  });
+
+  it('extracts the design §D3 section', () => {
+    const d3 = input.citations.find((c) => c.ref === '§D3');
+    expect(d3).toBeTruthy();
+    expect(d3!.source).toBe('design');
+  });
+
+  it('zero missing citations', () => {
+    expect(input.missing_citations).toEqual([]);
+  });
+});
+
+describe('buildBuilderInput — DQ-tagged tasks carry forward the tag', () => {
+  it('T-19 (chip catalog) surfaces DQ-5', () => {
+    const input = buildBuilderInput({
+      task: task('T-19'),
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+    });
+    expect(input.dq_tags).toContain('DQ-5');
+  });
+
+  it('T-22 (journal) surfaces DQ-4', () => {
+    const input = buildBuilderInput({
+      task: task('T-22'),
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+    });
+    expect(input.dq_tags).toContain('DQ-4');
+  });
+});
+
+describe('buildBuilderInput — missing-citation surfacing', () => {
+  it('reports citations not found in either artifact', () => {
+    // Synthetic: build a task with a citation that doesn't exist anywhere.
+    const fakeTask: Task = {
+      ...task('T-01'),
+      citations: {
+        spec: [
+          { kind: 'BR', ref: 'BR-999' },
+          { kind: 'spec_section', ref: '§5' }, // exists
+        ],
+        design: [{ kind: 'design_section', ref: '§D99' }],
+      },
+    };
+    const input = buildBuilderInput({
+      task: fakeTask,
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+    });
+    expect(input.missing_citations).toEqual(
+      expect.arrayContaining(['BR-999', '§D99'])
+    );
+    // §5 still resolves successfully.
+    expect(input.citations.map((c) => c.ref)).toContain('§5');
+  });
+});
+
+describe('formatBuilderInputMarkdown', () => {
+  const input = buildBuilderInput({
+    task: task('T-01'),
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+  });
+  const md = formatBuilderInputMarkdown(input);
+
+  it('includes the task heading', () => {
+    expect(md).toMatch(/^# Task: T-01 — TypeScript types/);
+  });
+
+  it('includes the slice context', () => {
+    expect(md).toMatch(/Slice:\*\* 0 \(Foundation\)/);
+  });
+
+  it('embeds each cited body inside its own heading', () => {
+    expect(md).toMatch(/### §5 \(spec\)/);
+    expect(md).toMatch(/### §D3 \(design\)/);
+  });
+
+  it('includes the Verify line as its own section', () => {
+    expect(md).toMatch(/## Verify \(the per-task gate\)/);
+  });
+
+  it('lists context files', () => {
+    expect(md).toMatch(/## Project context files[\s\S]*CLAUDE\.md/);
+  });
+
+  it('shows the budget block', () => {
+    expect(md).toMatch(/## Budget/);
+    expect(md).toMatch(/tokens: ~/);
+    expect(md).toMatch(/wall clock:/);
+  });
+
+  it('does NOT include a missing-citations warning when none exist', () => {
+    expect(md).not.toMatch(/citations were not found/);
+  });
+
+  it('shows a clear warning when missing citations are present', () => {
+    const fake = buildBuilderInput({
+      task: {
+        ...task('T-01'),
+        citations: {
+          spec: [{ kind: 'BR', ref: 'BR-999' }],
+          design: [],
+        },
+      },
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+    });
+    const fakeMd = formatBuilderInputMarkdown(fake);
+    expect(fakeMd).toMatch(/citations were not found/);
+    expect(fakeMd).toMatch(/BR-999/);
+  });
+});

--- a/scripts/harness/lib/builder-input.ts
+++ b/scripts/harness/lib/builder-input.ts
@@ -1,0 +1,221 @@
+/**
+ * Assembles the per-task structured input that the builder agent receives.
+ *
+ * Pure: takes a Task plus already-loaded markdown strings, returns a typed
+ * BuilderInput. The CLI wrapper handles file I/O.
+ */
+
+import {
+  extractRequirement,
+  extractSpecSection,
+  type SpecParserOptions,
+} from './spec-parser';
+import type { Citation, Task } from './task-parser';
+
+export interface BuilderInputBudget {
+  /** Approximate token budget for the agent's invocation. */
+  tokens: number;
+  /** Wall-clock cap before the controller force-exits. */
+  wallClockMinutes: number;
+  /** How many times the controller will retry a `verify_fail` before escalating. */
+  retries: number;
+}
+
+export const DEFAULT_BUDGET: BuilderInputBudget = {
+  tokens: 100_000,
+  wallClockMinutes: 15,
+  retries: 2,
+};
+
+export interface ExtractedCitation {
+  /** The citation token, e.g. 'BR-7' or '§D3'. */
+  ref: string;
+  /** Verbatim text from the source artifact. */
+  body: string;
+  /** Where it came from. */
+  source: 'spec' | 'design';
+  /** True when extraction returned null and we surfaced the ref as missing. */
+  missing?: true;
+}
+
+export interface BuilderInput {
+  task_id: string;
+  description: string;
+  slice: number;
+  slice_name: string;
+  citations: ExtractedCitation[];
+  verify: string | null;
+  notes: string | null;
+  dq_tags: string[];
+  /** Files the agent should read for project conventions. Caller-supplied. */
+  context_files: string[];
+  /**
+   * Files the agent is permitted to create or modify. Currently caller-supplied;
+   * future controller will derive from design §D2 file map.
+   */
+  allowed_writes: string[];
+  budget: BuilderInputBudget;
+  /**
+   * Refs that were cited by the task but not found in the source artifact.
+   * The controller treats this as a structural error worth surfacing before
+   * dispatch — the agent can't satisfy citations that don't exist.
+   */
+  missing_citations: string[];
+}
+
+export interface BuildBuilderInputOptions {
+  task: Task;
+  specMarkdown: string;
+  designMarkdown: string;
+  contextFiles?: string[];
+  allowedWrites?: string[];
+  budget?: BuilderInputBudget;
+}
+
+/**
+ * Build a BuilderInput from a parsed Task plus the spec/design markdown.
+ *
+ * The function tries each citation in two ways:
+ *   - For section refs (`§N`, `§DN`): extract the whole section.
+ *   - For typed refs (`BR-N`, `AC-N`, etc.): extract the bullet.
+ *
+ * Citations that don't resolve are surfaced via `missing_citations` rather
+ * than thrown — this lets the caller decide whether to dispatch a partial
+ * input or halt.
+ */
+export function buildBuilderInput(
+  opts: BuildBuilderInputOptions
+): BuilderInput {
+  const {
+    task,
+    specMarkdown,
+    designMarkdown,
+    contextFiles = ['CLAUDE.md'],
+    allowedWrites = [],
+    budget = DEFAULT_BUDGET,
+  } = opts;
+
+  const citations: ExtractedCitation[] = [];
+  const missing: string[] = [];
+
+  for (const cite of task.citations.spec) {
+    const ext = resolveCitation(cite, specMarkdown, 'spec');
+    if (ext) citations.push(ext);
+    else missing.push(cite.ref);
+  }
+  for (const cite of task.citations.design) {
+    const ext = resolveCitation(cite, designMarkdown, 'design');
+    if (ext) citations.push(ext);
+    else missing.push(cite.ref);
+  }
+
+  return {
+    task_id: task.id,
+    description: task.description,
+    slice: task.slice,
+    slice_name: task.sliceName,
+    citations,
+    verify: task.verify,
+    notes: task.notes,
+    dq_tags: task.dqTags,
+    context_files: contextFiles,
+    allowed_writes: allowedWrites,
+    budget,
+    missing_citations: missing,
+  };
+}
+
+function resolveCitation(
+  cite: Citation,
+  markdown: string,
+  source: 'spec' | 'design'
+): ExtractedCitation | null {
+  const opts: SpecParserOptions = { required: false };
+
+  // Section refs (§N or §DN) → extract the whole section.
+  if (cite.kind === 'spec_section' || cite.kind === 'design_section') {
+    const body = extractSpecSection(markdown, cite.ref, opts);
+    if (body === null) return null;
+    return { ref: cite.ref, body, source };
+  }
+
+  // Typed refs (BR-N, AC-N, NFR-N, US-N, OQ-N, DQ-N) → extract the bullet.
+  const body = extractRequirement(markdown, cite.ref, opts);
+  if (body === null) return null;
+  return { ref: cite.ref, body, source };
+}
+
+/**
+ * Render a BuilderInput as a human-readable / agent-readable markdown blob,
+ * ready to drop into a prompt. The system prompt (builder.md) goes ABOVE
+ * this; the structured input is the task-specific payload.
+ */
+export function formatBuilderInputMarkdown(input: BuilderInput): string {
+  const out: string[] = [];
+  out.push(`# Task: ${input.task_id} — ${input.description}`);
+  out.push('');
+  out.push(`**Slice:** ${input.slice} (${input.slice_name})`);
+  if (input.dq_tags.length > 0) {
+    out.push(`**Open DQ tags:** ${input.dq_tags.join(', ')}`);
+  }
+
+  if (input.missing_citations.length > 0) {
+    out.push('');
+    out.push('> ⚠ The following citations were not found in the source');
+    out.push('> artifacts. Treat as a structural problem and prefer a');
+    out.push('> `spec_gap` exit over guessing:');
+    for (const m of input.missing_citations) out.push(`> - ${m}`);
+  }
+
+  out.push('');
+  out.push('## Cited spec/design context');
+  out.push('');
+  for (const c of input.citations) {
+    out.push(`### ${c.ref} (${c.source})`);
+    out.push('');
+    out.push(c.body);
+    out.push('');
+  }
+
+  if (input.verify) {
+    out.push('## Verify (the per-task gate)');
+    out.push('');
+    out.push(input.verify);
+    out.push('');
+  }
+
+  if (input.notes) {
+    out.push('## Notes');
+    out.push('');
+    out.push(input.notes);
+    out.push('');
+  }
+
+  out.push('## Project context files');
+  out.push('');
+  out.push('Read these for project conventions:');
+  for (const f of input.context_files) out.push(`- \`${f}\``);
+  out.push('');
+
+  if (input.allowed_writes.length > 0) {
+    out.push('## Files you may create or modify');
+    out.push('');
+    for (const w of input.allowed_writes) out.push(`- \`${w}\``);
+    out.push('');
+  } else {
+    out.push('## Files you may create or modify');
+    out.push('');
+    out.push(
+      '_None pre-specified. Derive from the cited design §D2 file map and stage only those._'
+    );
+    out.push('');
+  }
+
+  out.push('## Budget');
+  out.push('');
+  out.push(`- tokens: ~${input.budget.tokens.toLocaleString()}`);
+  out.push(`- wall clock: ${input.budget.wallClockMinutes} min`);
+  out.push(`- retries on verify_fail: ${input.budget.retries}`);
+
+  return out.join('\n');
+}

--- a/scripts/harness/lib/prompts/builder.md
+++ b/scripts/harness/lib/prompts/builder.md
@@ -1,0 +1,164 @@
+# Builder Agent — System Prompt
+
+You are the **builder** agent in a spec-anchored development harness. Your job
+is to take ONE task from a curated task list and implement it against a TDD
+loop, with strict drift-escalation discipline.
+
+You are NOT a feature designer, a planner, or a code reviewer. Those are
+separate roles. Stay in your lane.
+
+---
+
+## Inputs you receive
+
+Every invocation includes a structured **per-task input** (see `BuilderInput`):
+
+- `task_id` — e.g. `T-07`
+- `description` — task heading after the em-dash
+- `cited_spec_sections` — verbatim text of every spec section/requirement the
+  task cites. **Do not infer beyond what's here.**
+- `cited_design_sections` — verbatim text of every design section the task
+  cites
+- `verify` — the `Verify:` line from the task
+- `notes` — optional `Notes:` body, may include `[DQ-N]` tags
+- `dq_tags` — list of open design questions that touch this task
+- `context_files` — paths to project-convention files you should read
+  (CLAUDE.md, precedent feature files)
+- `allowed_writes` — file paths you are permitted to create or modify
+- `budget` — `{ tokens, wall_clock_minutes, retries }`
+
+You also have full Claude Code tool access scoped to the worktree.
+
+---
+
+## TDD discipline (non-negotiable)
+
+For every task:
+
+1. **Re-read** the cited spec/design sections. Do not trust your memory; do
+   not infer from the task description alone.
+2. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
+   form. Run them; confirm they fail (RED).
+3. **Implement minimum code** to make the tests pass (GREEN). Avoid
+   gold-plating.
+4. **Refactor.** Keep tests green.
+5. **Run the `Verify:` line literally.** It is the per-task gate.
+6. **Stage exactly the `allowed_writes` files.** No drive-by edits to
+   unrelated files. If you needed to touch something else, that's a
+   `SPEC_GAP` — see drift escalation below.
+7. **Commit** with a message that cites at least one of the spec/design
+   sections you just implemented. Format:
+   `<type>(<scope>): <subject> (<citation>)`
+   Example: `feat(incidents): activation FAB (BR-27, AC-18)`
+   The harness's commit-msg hook validates this; you cannot commit without
+   a citation.
+
+---
+
+## Drift escalation contract
+
+Your most important responsibility after correctness: **never silently expand
+scope**. If you encounter ANY of the following, stop and emit a `SPEC_GAP`
+exit instead of pushing through:
+
+- A cited BR is ambiguous and you'd have to pick a default.
+- A cited design section conflicts with project convention you discovered
+  while reading the precedent files.
+- The Verify line is impossible without writing code outside `allowed_writes`.
+- A required type/function from a different feature module is missing or has
+  a different shape than the design says.
+- You discover a behavior the spec doesn't cover that is genuinely needed
+  for the task to function.
+
+In every case, the right move is the same: **stop, surface the gap, exit.**
+The drift-arbiter agent will resolve it (amend the spec, amend the design,
+or push back to clarify) and you'll be re-dispatched with refreshed context.
+
+You MUST NOT:
+
+- Silently invent a default value.
+- Make implementation choices the design phase didn't make.
+- Touch files outside `allowed_writes` "just to make it work".
+- Skip a test because the cited AC is hard to verify.
+- Lie about Verify passing — if you cannot run it cleanly, that's a
+  `verify_fail` exit, not a `success`.
+
+---
+
+## Output contract
+
+Exit with exactly one of these structured payloads (YAML or JSON, your
+choice — controller parses both):
+
+### success
+
+```yaml
+status: success
+commit_sha: <40-char SHA>
+verify_run:
+  typecheck: pass
+  lint: pass
+  test: pass
+  build: pass # only if the task touches build-relevant files
+files_touched:
+  - <path>
+notes: |
+  <free-form, optional — anything the cold-reader should know>
+```
+
+### spec_gap
+
+```yaml
+status: spec_gap
+cited_section: BR-N | §DN | etc.
+gap_description: |
+  <one paragraph describing what was unclear or missing>
+suggested_amendment: |
+  <one paragraph proposing the smallest possible spec/design change>
+files_inspected:
+  - <relevant precedent files you read while discovering the gap>
+```
+
+### verify_fail
+
+```yaml
+status: verify_fail
+verify_command: <the exact command that failed>
+output_tail: |
+  <last ~30 lines of failed output>
+attempts: <how many times you tried this iteration>
+```
+
+### budget_exceeded
+
+```yaml
+status: budget_exceeded
+spent:
+  tokens: <approx>
+  wall_clock_minutes: <approx>
+last_action: |
+  <one sentence on what you were doing when you hit the cap>
+```
+
+---
+
+## Things you do NOT do
+
+- You do not pick the next task. The controller does that.
+- You do not review your own work for spec compliance. The cold-reader does
+  that, in a separate session, with no memory of yours.
+- You do not amend the spec or design. The drift-arbiter does that, on
+  receipt of your `spec_gap` exit.
+- You do not push to remote. The controller does that after the cold-reader
+  approves.
+- You do not navigate slice boundaries. The controller halts at boundaries
+  and prompts the human.
+
+---
+
+## Style
+
+Match `CLAUDE.md` and the existing project conventions discovered in
+`context_files`. Project-specific rules ALWAYS override your defaults.
+When in doubt, mirror the precedent files literally — that's what the design
+phase chose them as the precedent for.

--- a/scripts/harness/lib/spec-parser.test.ts
+++ b/scripts/harness/lib/spec-parser.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  extractRequirement,
+  extractRequirements,
+  extractSpecSection,
+  extractSpecSections,
+} from './spec-parser';
+
+const root = resolve(__dirname, '../../../docs/specs/incident-capture');
+const specMd = readFileSync(`${root}/01-spec.md`, 'utf8');
+const designMd = readFileSync(`${root}/02-design.md`, 'utf8');
+
+describe('extractSpecSection — against real spec/design', () => {
+  it('extracts spec §5 (data model) including the heading', () => {
+    const out = extractSpecSection(specMd, '§5');
+    expect(out).toBeTruthy();
+    expect(out!).toMatch(/^## §5 Data Model/);
+    // Should contain the petId field documented in the data model.
+    expect(out!).toMatch(/`petId`/);
+  });
+
+  it('stops at the next ## heading (does not include §6)', () => {
+    const out = extractSpecSection(specMd, '§5')!;
+    expect(out).not.toMatch(/^## §6/m);
+    expect(out).not.toMatch(/Non-Functional Requirements/);
+  });
+
+  it('extracts design §D3 (data model concrete) including TypeScript types', () => {
+    const out = extractSpecSection(designMd, '§D3');
+    expect(out).toBeTruthy();
+    expect(out!).toMatch(/^## §D3 Data Model/);
+    // Should contain the Incident interface from the TypeScript section.
+    expect(out!).toMatch(/interface Incident/);
+  });
+
+  it('returns null for an unknown ref by default', () => {
+    expect(extractSpecSection(specMd, '§99')).toBeNull();
+    expect(extractSpecSection(designMd, '§D99')).toBeNull();
+  });
+
+  it('throws when required: true and ref is missing', () => {
+    expect(() => extractSpecSection(specMd, '§99', { required: true })).toThrow(
+      /spec section §99 not found/
+    );
+  });
+});
+
+describe('extractRequirement — against real spec', () => {
+  it('extracts BR-2 (timer at moment of gesture)', () => {
+    const out = extractRequirement(specMd, 'BR-2');
+    expect(out).toBeTruthy();
+    expect(out!).toMatch(/^- \*\*BR-2\*\*/);
+    expect(out!).toMatch(/timer MUST start/i);
+  });
+
+  it('extracts AC-1 with Given/When/Then body', () => {
+    const out = extractRequirement(specMd, 'AC-1');
+    expect(out).toBeTruthy();
+    expect(out!).toMatch(/^- \*\*AC-1/);
+    expect(out!).toMatch(/_Given_/);
+    expect(out!).toMatch(/_when_/);
+    expect(out!).toMatch(/_then_/);
+  });
+
+  it('extracts NFR-2 (activation latency, reframed)', () => {
+    const out = extractRequirement(specMd, 'NFR-2');
+    expect(out).toBeTruthy();
+    expect(out!).toMatch(/Activation latency/);
+  });
+
+  it('extracts the tombstoned AC-14 (does not skip tombstones by default)', () => {
+    const out = extractRequirement(specMd, 'AC-14');
+    expect(out).toBeTruthy();
+    expect(out!).toMatch(/tombstoned/);
+  });
+
+  it('returns null for an unknown ref', () => {
+    expect(extractRequirement(specMd, 'BR-999')).toBeNull();
+  });
+
+  it('does NOT match a citation that just mentions BR-N — only the bullet definition', () => {
+    // BR-26 is referenced inside many other BRs' bodies. The function should
+    // match only the actual `- **BR-26**` bullet, not the in-text references.
+    const out = extractRequirement(specMd, 'BR-26');
+    expect(out).toBeTruthy();
+    // The body should start with `- **BR-26**`.
+    expect(out!.split('\n')[0]).toMatch(/^- \*\*BR-26\*\*/);
+  });
+});
+
+describe('extractRequirement — fixture cases', () => {
+  it('captures continuation lines that are indented', () => {
+    const md = `## §4 BRs
+- **BR-1** — first line.
+  with an indented second line.
+  and a third.
+- **BR-2** — next bullet starts here.
+`;
+    const out = extractRequirement(md, 'BR-1');
+    expect(out).toBe(
+      [
+        '- **BR-1** — first line.',
+        '  with an indented second line.',
+        '  and a third.',
+      ].join('\n')
+    );
+  });
+
+  it('stops at the next ### heading', () => {
+    const md = `## §4 BRs
+
+### Group A
+- **BR-1** — first.
+- **BR-2** — second.
+
+### Group B
+- **BR-3** — third.
+`;
+    const out = extractRequirement(md, 'BR-2');
+    expect(out).toBe('- **BR-2** — second.');
+  });
+});
+
+describe('batch helpers', () => {
+  it('extractRequirements returns matched refs in order, skipping unknowns', () => {
+    const out = extractRequirements(specMd, ['BR-1', 'BR-999', 'AC-1']);
+    expect(out.map((r) => r.ref)).toEqual(['BR-1', 'AC-1']);
+    expect(out[0]?.body).toMatch(/^- \*\*BR-1\*\*/);
+  });
+
+  it('extractSpecSections returns matched sections in order', () => {
+    const out = extractSpecSections(specMd, ['§5', '§99', '§6']);
+    expect(out.map((r) => r.ref)).toEqual(['§5', '§6']);
+    expect(out[0]?.body).toMatch(/^## §5/);
+    expect(out[1]?.body).toMatch(/^## §6/);
+  });
+});

--- a/scripts/harness/lib/spec-parser.ts
+++ b/scripts/harness/lib/spec-parser.ts
@@ -1,0 +1,129 @@
+/**
+ * Extracts cited regions (whole sections, individual requirements) from a
+ * spec or design markdown file.
+ *
+ * Inputs are the raw markdown strings; outputs are plain strings ready to
+ * paste into a builder-agent prompt. Pure: no I/O, no project imports.
+ *
+ * Spec sections are headed `## §N <name>` (or `## §DN <name>` for design).
+ * Requirements are list bullets starting with `- **BR-N**`, `- **AC-N**`, etc.
+ *
+ * Tombstoned requirements (e.g. `**AC-14 (tombstoned ...)**`) ARE returned
+ * if explicitly requested — callers decide whether to surface them. The
+ * default `extractRequirement()` includes them; `excludeTombstones` filters.
+ */
+
+export interface SpecParserOptions {
+  /** When true, throw if the requested ref isn't found. Default false (returns null). */
+  required?: boolean;
+}
+
+const SECTION_HEADING_RE = /^##\s+(§D?\d+)\b/;
+
+/**
+ * Extract a whole section by ref, e.g. `§5` (spec) or `§D3` (design).
+ * Returns the heading + all body content up to (but not including) the next
+ * `## ` heading. Returns `null` if not found and `required: false`.
+ */
+export function extractSpecSection(
+  markdown: string,
+  ref: string,
+  opts: SpecParserOptions = {}
+): string | null {
+  const lines = markdown.split('\n');
+  let startIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const m = SECTION_HEADING_RE.exec(lines[i]!);
+    if (m && m[1] === ref) {
+      startIdx = i;
+      break;
+    }
+  }
+  if (startIdx === -1) {
+    if (opts.required) throw new Error(`spec section ${ref} not found`);
+    return null;
+  }
+
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (lines[i]!.startsWith('## ')) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  return lines.slice(startIdx, endIdx).join('\n').trim();
+}
+
+/**
+ * Extract a single requirement bullet by ref (BR-N, AC-N, NFR-N, US-N, OQ-N, DQ-N).
+ * Captures the bullet's first line plus any indented continuation lines.
+ *
+ * Returns null if the ref isn't present and `required: false`.
+ */
+export function extractRequirement(
+  markdown: string,
+  ref: string,
+  opts: SpecParserOptions = {}
+): string | null {
+  // Match `- **<REF>` (with optional trailing parenthetical: `- **AC-1 (US-1, BR-1)**`).
+  const refEscaped = ref.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const bulletRe = new RegExp(`^-\\s+\\*\\*${refEscaped}\\b`);
+
+  const lines = markdown.split('\n');
+  let startIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (bulletRe.test(lines[i]!)) {
+      startIdx = i;
+      break;
+    }
+  }
+  if (startIdx === -1) {
+    if (opts.required) throw new Error(`requirement ${ref} not found`);
+    return null;
+  }
+
+  // Continuation: subsequent lines that are blank, indented, or start with a
+  // sub-bullet ("  - ..."). Stop at the next top-level bullet or heading.
+  let endIdx = startIdx + 1;
+  while (endIdx < lines.length) {
+    const line = lines[endIdx]!;
+    if (line.startsWith('## ') || line.startsWith('### ')) break;
+    // Top-level bullet (- foo or * foo) at column 0 ends the previous bullet.
+    if (/^[-*]\s/.test(line)) break;
+    endIdx += 1;
+  }
+
+  return lines.slice(startIdx, endIdx).join('\n').trimEnd();
+}
+
+/**
+ * Extract many requirements at once, keeping order and skipping refs not found.
+ * Each entry is `{ ref, body }`.
+ */
+export function extractRequirements(
+  markdown: string,
+  refs: string[]
+): Array<{ ref: string; body: string }> {
+  const out: Array<{ ref: string; body: string }> = [];
+  for (const ref of refs) {
+    const body = extractRequirement(markdown, ref);
+    if (body !== null) out.push({ ref, body });
+  }
+  return out;
+}
+
+/**
+ * Extract many sections at once. Skips refs not found.
+ */
+export function extractSpecSections(
+  markdown: string,
+  refs: string[]
+): Array<{ ref: string; body: string }> {
+  const out: Array<{ ref: string; body: string }> = [];
+  for (const ref of refs) {
+    const body = extractSpecSection(markdown, ref);
+    if (body !== null) out.push({ ref, body });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Per the architecture plan §2 + §8, this PR builds the **context preparation pipeline** and **system prompt** for the builder agent. Actual subagent invocation is deferred to a separate step — the methodology says iterate the prompt FIRST, then automate dispatch, because each prompt iteration is cheap when not wired to the loop.

## Three new lib modules + a system prompt + a CLI command

### \`scripts/harness/lib/spec-parser.ts\` (~110 lines, 15 tests)

Pure section/requirement extraction from spec/design markdown:
- \`extractSpecSection(md, '§5')\` — whole section between \`##\` headings
- \`extractRequirement(md, 'BR-7')\` — single bullet with continuation lines
- Plus batch helpers \`extractRequirements\` / \`extractSpecSections\`

### \`scripts/harness/lib/builder-input.ts\` (~220 lines, 21 tests)

Assembles a parsed \`Task\` + spec/design markdown into a typed \`BuilderInput\`. Key design decisions:
- **Surfaces missing citations** as structured warnings — agent gets explicit "this BR-N you cited doesn't exist" rather than silent context drop.
- **Default budget**: 100k tokens, 15min wall-clock, 2 retries on \`verify_fail\` (matches plan §2).
- **\`formatBuilderInputMarkdown\`** renders the structured input as a markdown blob ready to drop into a prompt.

### \`scripts/harness/lib/prompts/builder.md\` (~160 lines)

The builder's system prompt. Codifies:
- TDD discipline: tests RED → impl GREEN → refactor → verify (literal command from \`Verify:\` line) → commit with citation
- **Drift-escalation contract**: 5 explicit triggers for emitting \`SPEC_GAP\` instead of silently expanding scope
- **Structured output format**: \`success | spec_gap | verify_fail | budget_exceeded\` with per-status YAML schemas
- **Things you do NOT do**: pick the next task, review own work, amend spec, push to remote, navigate slice boundaries

### \`scripts/harness/cli.ts\`: new \`prepare <task-id>\` command

Renders system prompt + per-task input markdown to stdout, ready to paste into a fresh Claude Code session for hand-driving:

\`\`\`
$ pnpm harness prepare T-01                      # full prompt + per-task
$ pnpm harness prepare T-17 --no-system-prompt   # per-task only
$ pnpm harness prepare T-01 --json               # machine form
\`\`\`

## End-to-end smoke

| Task | Citations | Output lines | Status |
|---|---|---|---|
| T-01 | §5, §D3 | 342 | ✓ |
| T-17 | BR-6,7,8,9,19,22 + §D3 | longer (multi-section) | ✓ |

Both produce builder-ready prompts with each cited BR/section as its own subheading inside the per-task input.

## Verify (per plan §8 step 4)

- \`pnpm exec tsc -b\`: ✓
- \`pnpm run test:unit\`: 709 passing (5 harness files now, 104 harness tests)
- \`pnpm run lint\`: clean
- Both \`prepare\` smoke tests above

## Stylistic finding (worth noting)

Original function name \`renderBuilderInputMarkdown\` tripped the \`testing-library/render-result-naming-convention\` lint rule (false positive — returns a string, not a React render). Renamed to \`formatBuilderInputMarkdown\` to break the prefix. Worth noting that lint rules can constrain naming choices in unexpected places when a project shares config across pure-Node and React code paths.

## What's next

MVP step 5: the cold-reader agent + bootstrap regression suite from PR #152's prose findings. Same shape — system prompt + context-prep + CLI command — but the cold-reader's positive/negative scope is the load-bearing design (see plan §5).

After that, MVP step 6 hand-drives T-01 end-to-end: paste the \`prepare T-01\` output into a fresh Claude Code session, observe what the agent actually does, iterate on the prompt based on real signal.