### PR TITLE
feat(harness): add 6th drift-escalation trigger (rule conflict) to builder prompt

### DIFF
--- a/scripts/harness/lib/prompts/builder.md
+++ b/scripts/harness/lib/prompts/builder.md
@@ -69,6 +69,19 @@ exit instead of pushing through:
   a different shape than the design says.
 - You discover a behavior the spec doesn't cover that is genuinely needed
   for the task to function.
+- **Two rules in this prompt itself conflict on this task.** Most commonly:
+  the TDD rule (#2 — "Write tests first; tests must assert the cited ACs")
+  presumes the task cites ACs and the verify line permits running tests
+  against the produced code. If the task cites no ACs AND the verify line is
+  structural (e.g. _"`tsc -b` passes with the new file imported nowhere"_),
+  the TDD rule has no clear application — there are no ACs to assert and
+  satisfying TDD by writing a test would import the file and break the verify
+  gate. **Even if you can navigate the conflict reasonably**, do not. Escalate.
+  The drift-arbiter will either amend the task/spec to remove the conflict
+  (e.g. revise the verify line to permit a type-only test, or add an explicit
+  task-level note that TDD does not apply) or apply a one-time pushback
+  authorizing your interpretation. Either way, the decision gets logged
+  rather than living silently in your reasoning.
 
 In every case, the right move is the same: **stop, surface the gap, exit.**
 The drift-arbiter agent will resolve it (amend the spec, amend the design,
@@ -80,6 +93,8 @@ You MUST NOT:
 - Make implementation choices the design phase didn't make.
 - Touch files outside `allowed_writes` "just to make it work".
 - Skip a test because the cited AC is hard to verify.
+- **Skip a test because the verify line forbids importing the produced code.**
+  That's a rule conflict — escalate per the trigger above.
 - Lie about Verify passing — if you cannot run it cleanly, that's a
   `verify_fail` exit, not a `success`.
 


### PR DESCRIPTION
## Summary

Round-17 e2e harness test surfaced a real tension in the builder system prompt that this PR fixes by amending the drift-escalation contract.

## What round-17 found

The first end-to-end harness run (builder + cold-reader on T-01 in a throwaway branch) produced \`status: success\` — but the builder had silently navigated a conflict between rule #2 (TDD: write tests first; assert cited ACs) and T-01's verify line (\`tsc -b\` passes with the new file imported nowhere). T-01 cites no ACs and the verify gate forbids imports, so writing a TDD test would break the gate. The builder skipped tests, explained in \`notes\`, and exited success. The cold-reader ratified.

That's defensible per literal task-completion. It's wrong per the methodology's "never silently navigate a rule conflict" discipline. The right move was to escalate as \`spec_gap\` so the conflict gets logged and resolved at the spec/task level, not lost in the builder's reasoning.

## The amendment

Adds a sixth explicit drift-escalation trigger:

> Two rules in this prompt itself conflict on this task. Most commonly: the TDD rule (#2) presumes the task cites ACs and the verify line permits running tests. If the task cites no ACs AND the verify line is structural (e.g. \`tsc -b\` passes with the new file imported nowhere), escalate. Even if you can navigate the conflict reasonably, do not.

Plus an explicit MUST-NOT entry mirroring the existing list: *"Skip a test because the verify line forbids importing the produced code — that's a rule conflict, escalate per the trigger above."*

## Empirical validation (V1 vs V2 head-to-head)

Re-ran the round-17 e2e test on T-01 with V2 of the prompt. Builder behavior changed exactly as designed:

| Prompt | Outcome | Time | Tokens | Tool uses |
|---|---|---|---|---|
| V1 (round 17) | \`success\` (silent navigation) | 93s | 65k | 9 |
| V2 (this PR) | \`spec_gap\` (escalation) | 27s | 46k | 2 |

V2 escalation is meaningfully cheaper — no implementation work happens before the conflict is surfaced. That's the early-exit win you'd want from a properly-escalating builder.

The V2 builder explicitly named the new sixth trigger as the reason for escalation, described the conflict accurately, and proposed two reasonable resolutions (revise verify line + waive TDD for type-only files; OR keep verify line + add task-level pushback note). Bonus: it also caught a scope ambiguity about whether \`IncidentCreateInput\`/\`IncidentUpdateInput\` belong in T-01 since they're derived types not strictly in §5 spec — exactly the kind of "I'm about to make a silent decision; surface it instead" finding the trigger is supposed to produce.

## Verify

- \`pnpm exec tsc -b\`: ✓
- \`pnpm run test:unit\`: 738 passing
- \`pnpm run lint\`: clean
- V1-vs-V2 head-to-head on T-01: V1 silent-success, V2 escalation. Behavior change matches the prompt amendment.

## What this PR doesn't do

- Doesn't apply either of the V2 builder's suggested resolutions to T-01 itself. That's a separate task — modifying \`docs/specs/incident-capture/03-tasks.md\` is a different concern from iterating the builder prompt.
- Doesn't build the drift-arbiter agent. Per plan §8 step 7, that's the natural next step now that we have a real \`SPEC_GAP\` event to seed the arbiter's design from. Belongs in its own PR.

## Methodology note (worth surfacing)

The "use the tool on the tool" pattern (rounds 12, 15, 17) generalizes to a clean V1-vs-V2 prompt comparison: spawn fresh subagent twice with different prompt versions on the same case, compare structured outputs. Captured as PL-1 in the session log §9 — model-agnostic prompt-evaluation toolchain — for future build-out.