### PR TITLE
docs(spec): apply drift-arbiter amendment to T-01 (TDD waiver) — closes round-17/18/19 loop

### DIFF
--- a/docs/specs/incident-capture/03-tasks.md
+++ b/docs/specs/incident-capture/03-tasks.md
@@ -24,6 +24,7 @@ Groundwork that has zero user-visible effect but unblocks all downstream slices.
 - **Cite:** spec §5 (data model); design §D3 (TypeScript types)
 - **What:** Create `src/features/incidents/types.ts` with `Incident`, `IncidentTypeId`, `Severity`, `ChipId`, `JournalEntry`, `IncidentCreateInput`, `IncidentUpdateInput`. Include the BR-29 runtime-invariant comment from design §D3.
 - **Verify:** `pnpm exec tsc -b` passes with the new file imported nowhere.
+- **Notes:** TDD-first is waived for this task. §D3 specifies type declarations, not behavior, and the verify gate is intentionally structural (file imported nowhere) to keep slice 0 dependency-free. These types will be exercised by the first consumer's tests in a downstream task; do not write a self-contained test that imports this file.
 
 ### `[ ]` T-02 — Feature flag
 
@@ -330,3 +331,4 @@ Goal after this slice: a single-pet user can tap a global FAB, see a running tim
 ## §T0 Tasks Changelog
 
 - **2026-05-01** — Initial draft. 47 tasks across 5 slices + foundation. Tasks reference spec/design at the time of authoring; if spec/design amend, T- entries here may need re-citation.
+- **2026-05-01** — T-01: added `Note` waiving TDD-first for this pure type-declaration task; resolves spec_gap from T-01 (TDD rule vs. structural "imported nowhere" verify gate). Spec/design unchanged. Amendment proposed by drift-arbiter agent (round 19) and applied verbatim.

--- a/scripts/harness/lib/builder-input.test.ts
+++ b/scripts/harness/lib/builder-input.test.ts
@@ -44,9 +44,12 @@ describe('buildBuilderInput — T-01 (foundation, smallest surface)', () => {
     expect(designD3.body).toMatch(/interface Incident/);
   });
 
-  it('passes through the Verify line and absence of notes', () => {
+  it('passes through the Verify line and the TDD-waiver Notes', () => {
     expect(input.verify).toMatch(/tsc -b/);
-    expect(input.notes).toBeNull();
+    // T-01 carries a TDD-first waiver Note added by the drift-arbiter
+    // (round 19) and applied as a follow-up amendment (round 20).
+    // Previously this test asserted notes was null.
+    expect(input.notes).toMatch(/TDD-first is waived/);
     expect(input.dq_tags).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Closes the conceptual loop that opened in round 17 with the TDD-vs-verify-line conflict.

- **Round 17:** end-to-end harness test surfaced the conflict (V1 builder silently navigated).
- **Round 18:** amended the builder system prompt so the conflict surfaces as \`spec_gap\` (PR #158).
- **Round 19:** built the drift-arbiter agent; hand-test against round-18's spec_gap produced an \`amend_task\` proposal (PR #159).
- **Round 20 (this PR):** apply the proposed amendment to \`03-tasks.md\` and validate the V2 builder now succeeds against the amended task.

## What landed

- T-01 in \`03-tasks.md\` gains a \`Notes\` line waiving TDD-first for this pure type-declaration task. Spec (§5) and design (§D3) are unchanged — they correctly specify the data shape; only the task's local framing needed adjustment.
- A §T0 changelog entry per the methodology's append-only rule.
- One follow-up test fix: \`builder-input.test.ts\` previously asserted T-01 had no notes; the amendment legitimately invalidates that. Updated the assertion to expect the TDD-waiver text.

## V1 → V2 → arbiter → applied: full cycle

| Round | Prompt / artifact | Outcome | Time | Tokens |
|---|---|---|---|---|
| 17 | V1 builder, original T-01 | \`success\` (silent navigation — wrong) | 93s | 65k |
| 18 | V2 builder, original T-01 | \`spec_gap\` (correct escalation) | 27s | 46k |
| 19 | drift-arbiter, round-18 spec_gap | proposed \`amend_task\` | 21s | 40k |
| 20 (this) | V2 builder, **amended** T-01 | \`success\` (correct) | 88s | 47k |

The methodology produced a working escalation/resolution pipeline from a single observed conflict, validated empirically at every step.

## Real prompt-iteration finding caught during application

The arbiter wrote \`**Note:**\` (singular) but the parser's field grammar only accepts \`**Notes:**\` (plural — see \`scripts/harness/lib/task-parser.ts\` FIELD_LINE regex). I applied the amendment with the plural form, but this surfaces a gap in the arbiter's input: the arbiter doesn't currently know about the parser's field grammar.

**Future arbiter-prompt iteration to consider:** include the parser's valid field names (\`Cite\`, \`What\`, \`Verify\`, \`Notes\`) in the arbiter's input or system prompt so its proposed amendments are syntactically valid as written. Filed in the session log as a resurrection cue.

## Verify

- \`pnpm exec tsc -b\`: ✓
- \`pnpm exec vitest run scripts/harness/lib/\`: 172 harness tests pass (with the updated assertion)
- \`pnpm run lint\`: clean
- \`pnpm harness prepare T-01\`: Notes section now renders in the builder-input output
- **Empirical validation (round 20 hand-test):** V2 builder produced \`status: success\` against amended T-01, recognized the task notes as authoritative per-task carve-out (rather than escalating). \`pnpm exec tsc -b\` passed in the experimental commit; lint and tests passed.

## Pre-push hook flake noted

Pre-push (\`test:coverage\`) flaked once on this PR (the same intermittent issue first observed in round 12 — async timing under coverage instrumentation hitting either LanguageSelector or App.authGuard tests). Reproduces on main; not caused by this change. Standing follow-up to investigate / fix; not blocking this merge.

## What's next

The methodology has now produced its first complete spec-anchored deliverable: T-01 (with the TDD waiver). Natural next steps after merge:

- Continue end-to-end on T-02..T-05 (rest of foundation slice) with the V2 builder + cold-reader prompts.
- Or wire actual subagent dispatch in the controller to make the harness self-driving.