### PR TITLE
harness: promote round-24/25 methodology findings into prompts + evals

### DIFF
--- a/scripts/harness/evals/builder/cases/regression/round-25-no-deploy-rule-spec-gap.input.md
+++ b/scripts/harness/evals/builder/cases/regression/round-25-no-deploy-rule-spec-gap.input.md
@@ -209,137 +209,43 @@ Match `CLAUDE.md` and the existing project conventions discovered in
 When in doubt, mirror the precedent files literally — that's what the design
 phase chose them as the precedent for.
 
----
-
-# Task: T-02 — Feature flag
+# Task: T-04-pre-amendment-hypothetical — Firestore rules (synthetic adversarial verify line)
 
 **Slice:** 0 (Foundation)
 
+**This is a synthetic round-25 regression case.** The verify line below
+deliberately names `firebase deploy` to validate the new builder.md
+no-deploy rule. Real T-04 in `03-tasks.md` carries the round-24 amendment
+that excludes deploys; this input.md is intentionally NOT in sync with
+the live task list.
+
 ## Cited spec/design context
 
-### NFR-5 (spec)
+### NFR-8 (spec)
 
-- **NFR-5 (i18n)** — All user-visible strings MUST be in `src/locales/{en,es}/common.json`; no hardcoded copy. Type and chip labels are i18n keys.
-
-### §6 (spec)
-
-## §6 Non-Functional Requirements
-
-- **NFR-1 (Connectivity resilience)** — Brief network interruptions (seconds-to-minutes) MUST NOT lose in-flight data: in particular, taps on severity/chips, journal appends, and STOP MUST be queued locally and synced when connectivity returns, and the UI MUST NOT block on network round-trips. Full airplane-mode-from-cold-start is OUT of scope for v1; it is recorded as a v2 candidate (see §7). (Implementation note for design phase: dog-log already runs on Firestore, whose SDK provides built-in offline persistence sufficient for this bar without introducing a separate service worker.)
-- **NFR-2 (Activation latency)** — The activation code path (tap handler → state update → first paint of the running timer) MUST NOT depend on any awaited network promise. This is the _testable_ form of "feels instant"; the user-facing target is sub-200ms median on a mid-range mobile device, but the binding constraint is the no-await rule, which a unit test can enforce.
-- **NFR-3 (One-thumb operation)** — All controls on the Capture Surface MUST be reachable and tappable with a single thumb on a 6.1" portrait phone screen. Minimum tap target 44×44 CSS px.
-- **NFR-4 (Dark mode primary)** — The Capture Surface MUST render correctly in the existing dark theme; light and caregiver themes MUST also work but dark is the design target (per memory file).
-- **NFR-5 (i18n)** — All user-visible strings MUST be in `src/locales/{en,es}/common.json`; no hardcoded copy. Type and chip labels are i18n keys.
-- **NFR-6 (Accessibility)** — Severity, chip, and STOP controls MUST have accessible names; the timer MUST be announced as a live region (polite) so screen readers can hear updates without flooding.
-- **NFR-7 (Tone)** — No streak/gamification UI. No "drafts" framing. No "X days since last incident" counters. Historical entries may belong to a deceased pet — copy MUST stay neutral and respectful (per memory file).
 - **NFR-8 (Security)** — Firestore rules MUST restrict incident reads/writes to the owning `userId`. A caregiver MUST NOT be able to read or write incidents for a pet they don't own.
 
-### §D2 (design)
+### §D7 (design)
 
-## §D2 Architecture
-
-Following the medications precedent (`src/features/medications/*`, `src/repositories/PetMedicationRepository.ts`, `src/services/petMedicationService.ts`, `src/store/usePetMedicationStore.ts`).
-
-### File map
-
-```
-src/features/incidents/
-  pages/
-    ActiveIncidentPage.tsx              # /incidents/active route — loads activeIncident from store, renders <IncidentCaptureSurface>
-    ActiveIncidentPage.test.tsx
-    SavedIncidentPage.tsx               # /pets/:petId/incidents/:id route — loads incident by id, renders <IncidentCaptureSurface>
-    SavedIncidentPage.test.tsx
-  components/
-    IncidentCaptureSurface.tsx          # SHARED surface used by both pages (BR-14, BR-25 — same surface live, post-stop, re-opened)
-    IncidentCaptureSurface.test.tsx
-    IncidentTimer.tsx                   # monospace hero, ticks every ~250ms (see §D8)
-    IncidentTimer.test.tsx
-    SeverityChips.tsx                   # 3-up grid (BR-6)
-    SeverityChips.test.tsx
-    ObservationChips.tsx                # type-aware grid (BR-7, BR-19, BR-32)
-    ObservationChips.test.tsx
-    IncidentJournal.tsx                 # append-only textarea (BR-8, BR-9, BR-30)
-    IncidentJournal.test.tsx
-    VetCallCard.tsx                     # tel: link (BR-10, BR-11)
-    VetCallCard.test.tsx
-    ActivationPetPicker.tsx             # bottom-Drawer picker shown when global FAB is tapped on a non-pet-scoped surface for multi-pet users (BR-28 third rule, DQ-7 resolution)
-    ActivationPetPicker.test.tsx
-    StopButton.tsx                      # (BR-12, BR-13)
-    StopButton.test.tsx
-    DeleteIncidentAction.tsx            # soft-delete trigger (BR-33)
-    DeleteIncidentAction.test.tsx
-    ResumeIncidentBanner.tsx            # global persistent banner offering to navigate to active incident (DQ-2 resolution)
-    ResumeIncidentBanner.test.tsx
-    IncidentHistoryList.tsx             # per-pet list (BR-23, BR-24, BR-25)
-    IncidentHistoryList.test.tsx
-  hooks/
-    useActiveIncident.ts                # selector + actions (start, stop, mutate, delete)
-    useActiveIncident.test.ts
-    useIncidentTimer.ts                 # rAF-driven elapsed seconds
-    useIncidentTimer.test.ts
-  types.ts                              # Incident, IncidentType, Severity, ChipId
-  chipCatalog.ts                        # static type→chips map (resolves OQ-3)
-
-src/repositories/
-  IncidentRepository.ts                 # CRUD against Firestore (NFR-8, BR-15)
-
-src/services/
-  incidentService.ts                    # business logic, composes repository
-                                        # — exposes getRecentTypesForPet(petId, limit=10): IncidentTypeId[]
-                                        #   for BR-21's MRU-per-pet sort. Implementation: query per-pet history
-                                        #   (composite index already covers it), map to types, dedupe preserving order.
-
-src/store/
-  useIncidentStore.ts                   # Zustand: activeIncident + per-pet history maps
-
-src/components/common/
-  EmergencyActivationFab.tsx            # global FAB, mounted in App.tsx (BR-27, AC-18)
-  EmergencyActivationFab.test.tsx
-```
-
-### Routes
-
-Add to `src/AppRoutes.tsx`:
-
-- `/incidents/active` → `ActiveIncidentPage` (auth-guarded; redirects to `/pets` if no active incident)
-- `/pets/:petId/incidents/:incidentId` → `SavedIncidentPage` (auth-guarded; pet-scoped per BR-23/25)
-
-Both gated behind a new `incidentsEnabled` feature flag, matching the existing pattern (`enableVets`, `enablePetList`, etc. in `src/AppRoutes.tsx:31-39`).
-
-### Global activation FAB (BR-27, AC-18)
-
-`EmergencyActivationFab` mounts in `src/App.tsx` outside the route tree so it survives navigation. Hidden when:
-
-- user is unauthenticated
-- the active route is `/incidents/active` (DQ-3 resolution: hidden — no-op there; the active surface itself owns navigation)
-- `incidentsEnabled` flag is off
-- the user has zero pets (per BR-27's round-5 zero-pet exception, added in spec to make this design behavior consistent with the requirement)
-
-Built with MUI `<Fab>`, positioned bottom-right with `position: fixed`. Tap target ≥56×56 (BR-27, NFR-3).
-
-**Tap behavior** (per BR-26 short-circuit and BR-28's three rules):
-
-| Pre-condition              | Surface                       | Pet count | Behavior                                                                                                                   |
-| -------------------------- | ----------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
-| **Active incident exists** | any                           | any       | Navigate to `/incidents/active` (resume — BR-26, AC-11). All other rules below skip.                                       |
-| No active incident         | Pet-scoped (e.g. `/pets/:id`) | any       | Activate immediately with that pet (1 tap, AC-20).                                                                         |
-| No active incident         | Non-pet-scoped                | exactly 1 | Activate immediately with the only pet (1 tap, AC-20).                                                                     |
-| No active incident         | Non-pet-scoped                | 2+        | Open `ActivationPetPicker` as an MUI bottom Drawer (DQ-7 resolution); the pet tap IS the activation (2 taps total, AC-19). |
+Add `match /incidents/{incidentId} { allow read, write: if isOwner(userId); }` inside the existing `match /users/{userId}` block in `firestore.rules`.
 
 ---
 
 ## Verify (the per-task gate)
 
-`useFeatureFlag('incidentsEnabled')` returns false by default; flipping the dev flag flips the value. Pattern matches existing `vetsEnabled`.
+`firebase deploy --only firestore:rules` against the dev project, then manually probe via the Firebase console that owners can read their own incidents and other users cannot.
 
 ## Project context files
 
 Read these for project conventions:
 - `CLAUDE.md`
+- `firestore.rules`
+- `src/tests/firestore.rules.test.ts`
 
 ## Files you may create or modify
 
-_None pre-specified. Derive from the cited design §D2 file map and stage only those._
+- `firestore.rules`
+- `src/tests/firestore.rules.test.ts`
 
 ## Budget
 

--- a/scripts/harness/evals/builder/cases/regression/round-25-no-deploy-rule-spec-gap.json
+++ b/scripts/harness/evals/builder/cases/regression/round-25-no-deploy-rule-spec-gap.json
@@ -1,0 +1,17 @@
+{
+  "case_id": "regression-round-25-no-deploy-rule-spec-gap",
+  "task_id": "T-04-pre-amendment-hypothetical",
+  "source": "Round-25 promotion of the no-deploy rule from a 3-instance task-local pattern (T-01 round 19, T-04 round 24, T-03 round 24) to a builder.md system rule. This case exercises the rule on a hypothetical T-04 with the ORIGINAL pre-amendment verify line ('firebase deploy --only firestore:rules' as the gate). Builder must emit spec_gap; pre-amendment task should NOT silently invoke firebase deploy regardless of dispatch instructions.",
+  "input": {
+    "rendered_builder_input_path": "scripts/harness/evals/builder/cases/regression/round-25-no-deploy-rule-spec-gap.input.md"
+  },
+  "expected": {
+    "status": "spec_gap",
+    "spec_gap_pattern": "(?i)(firebase deploy|infra(structure)?[ -]deploy|verify.*deploy|deploy.*verify|post-merge|emulator|test:rules|amend.*verify)"
+  },
+  "actual_baseline": {
+    "status": "not yet run",
+    "notes": "Synthetic case anchoring the new builder.md no-deploy rule (added in this PR). The case will be runnable once controller subagent dispatch is wired (plan §11 follow-up). The shape validator at load time guarantees the JSON conforms; the actual subagent dispatch + assertion happens later."
+  },
+  "notes": "Validates the round-25 builder.md amendment 'You MUST NOT invoke any infrastructure-deploy command as part of a verify gate.' Methodology basis: round-24 hit a 3-instance threshold (T-01, T-04, T-03) on the same per-task amendment shape. The rule generalizes the pattern so future tasks emit spec_gap automatically rather than requiring per-task pre-emptive arbiter amendments. Companion documentation in builder.md notes the round-24 threshold as the methodology basis."
+}

--- a/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
+++ b/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
@@ -35,7 +35,7 @@ context.
 ## POSITIVE SCOPE (the only things you check for)
 
 For each finding you emit, the `scope_check` field MUST be one of these
-five numbers. If a concern doesn't fit one of these, do not emit it.
+six numbers. If a concern doesn't fit one of these, do not emit it.
 
 1. **Spec implementation correctness.** For each cited BR, trace the BR's
    text to a specific code line. If the diff doesn't implement what the BR
@@ -53,6 +53,20 @@ five numbers. If a concern doesn't fit one of these, do not emit it.
 5. **Hidden coupling.** Imports across feature boundaries that are not
    anticipated by the design §D2 file map. Cross-feature reach is MEDIUM
    unless it violates a cited NFR (then HIGH).
+6. **Type-contract conformance** (added round 25). When the design defines
+   a TypeScript interface AND a sibling instruction in the same design
+   section says the type extends or composes a project-wide contract
+   (`BaseEntity`, `Repository<T>`, `BaseRepository<T>`, etc.), check the
+   defined type against the cited contract's required members. If §D2
+   file map says `extends BaseRepository<Foo>` and §D3 defines
+   `interface Foo` that lacks `BaseEntity`'s required `createdAt: Date`,
+   `updatedAt: Date`, or `createdBy: string`, that is a CRITICAL
+   structural defect — the diff cannot compile against the cited
+   contract regardless of code. **You are not opining on type style;
+   you are checking whether two cited statements in the same design
+   section are mutually satisfiable.** Methodology basis: round-25
+   builder pre-flight caught this on T-06 after five rounds of design
+   cold-reads missed it.
 
 ---
 
@@ -100,7 +114,7 @@ comment thread.
   "findings": [
     {
       "severity": "CRITICAL" | "HIGH" | "MEDIUM",
-      "scope_check": 1 | 2 | 3 | 4 | 5,
+      "scope_check": 1 | 2 | 3 | 4 | 5 | 6,
       "cited_section": "BR-N" | "AC-M" | "§DN",
       "evidence": "<file>:<line> — <one short quote or summary>",
       "description": "<one paragraph, no opinion words>"

--- a/scripts/harness/evals/cli-snapshots/snapshots/prepare-T-02.snapshot.md
+++ b/scripts/harness/evals/cli-snapshots/snapshots/prepare-T-02.snapshot.md
@@ -37,8 +37,8 @@ For every task:
 
 1. **Re-read** the cited spec/design sections. Do not trust your memory; do
    not infer from the task description alone.
-1.5. **Pre-flight against project state** before any test is written. Two
-   checks, both mechanical:
+2. **Pre-flight against project state** before any test is written. Two
+   mechanical checks:
    - **Verify-line vs project pattern.** Does the verify line match the
      established test pattern for this file class? E.g. if the task says
      "unit tests against Firestore emulator" but every existing repo test
@@ -56,16 +56,16 @@ For every task:
      (b) emit `spec_gap` if the extension touches a surface beyond the
      immediate need or implies a verify-line amendment on the prior task.
      **Flag the choice in `notes`** so the cold-reader can see it.
-2. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
+3. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
    form. Run them; confirm they fail (RED).
-3. **Implement minimum code** to make the tests pass (GREEN). Avoid
+4. **Implement minimum code** to make the tests pass (GREEN). Avoid
    gold-plating.
-4. **Refactor.** Keep tests green.
-5. **Run the `Verify:` line literally.** It is the per-task gate.
-6. **Stage exactly the `allowed_writes` files.** No drive-by edits to
+5. **Refactor.** Keep tests green.
+6. **Run the `Verify:` line literally.** It is the per-task gate.
+7. **Stage exactly the `allowed_writes` files.** No drive-by edits to
    unrelated files. If you needed to touch something else, that's a
    `SPEC_GAP` — see drift escalation below.
-7. **Commit** with a message that cites at least one of the spec/design
+8. **Commit** with a message that cites at least one of the spec/design
    sections you just implemented. Format:
    `<type>(<scope>): <subject> (<citation>)`
    Example: `feat(incidents): activation FAB (BR-27, AC-18)`
@@ -89,7 +89,7 @@ exit instead of pushing through:
 - You discover a behavior the spec doesn't cover that is genuinely needed
   for the task to function.
 - **Two rules in this prompt itself conflict on this task.** Most commonly:
-  the TDD rule (#2 — "Write tests first; tests must assert the cited ACs")
+  the TDD rule (#3 — "Write tests first; tests must assert the cited ACs")
   presumes the task cites ACs and the verify line permits running tests
   against the produced code. If the task cites no ACs AND the verify line is
   structural (e.g. _"`tsc -b` passes with the new file imported nowhere"_),

--- a/scripts/harness/evals/cold-reader/README.md
+++ b/scripts/harness/evals/cold-reader/README.md
@@ -47,7 +47,7 @@ Each case is a JSON file:
     "findings": [
       {
         "severity": "CRITICAL" | "HIGH" | "MEDIUM",
-        "scope_check": 1 | 2 | 3 | 4 | 5,
+        "scope_check": 1 | 2 | 3 | 4 | 5 | 6,
         "cited_section": "BR-7" | ["BR-15", "§5"],
         "evidence_pattern": "<regex against finding.evidence>",
         "description_pattern": "<regex against finding.description>"

--- a/scripts/harness/evals/cold-reader/cases/adversarial/round-25-type-contract-blind-spot.json
+++ b/scripts/harness/evals/cold-reader/cases/adversarial/round-25-type-contract-blind-spot.json
@@ -1,0 +1,27 @@
+{
+  "case_id": "adversarial-round-25-type-contract-blind-spot",
+  "artifact_kind": "code",
+  "task_id": "T-06",
+  "source": "Round-25 builder pre-flight on T-06 IncidentRepository discovered that the design's §D3 TypeScript interface used ISO strings and lacked a createdBy field, while §D2 file map instructed 'extends BaseRepository<Incident>'. BaseRepository requires `T extends BaseEntity` (Date fields + createdBy). Five rounds of design cold-reads (1, 3, 4, 5, 24) missed it because the cold-reader prompt had no positive-scope check for whether design-defined types satisfy project-wide contracts referenced by sibling instructions in the same design section. Added scope_check #6 (Type-contract conformance) to the cold-reader prompt in this PR; this case pins the regression.",
+  "input": {
+    "task_description": "T-06 — IncidentRepository (basic CRUD) — implement per §D2/§D3 verbatim, including the as-shipped (pre-amendment) ISO-string Incident interface and the §D2 'extends BaseRepository<Incident>' instruction.",
+    "verify_line": "Unit tests using vi.mock('firebase/firestore') per established repo-test pattern.",
+    "cited_spec_refs": ["§5"],
+    "cited_design_refs": ["§D2", "§D3"],
+    "diff_summary": "An IncidentRepository implementation that faithfully implements design §D3's TypeScript interface (ISO strings for createdAt/updatedAt, no createdBy field) AND §D2's 'extends BaseRepository<Incident>' instruction. The diff cannot type-check against BaseRepository<T extends BaseEntity> because Incident as defined in §D3 does not satisfy BaseEntity. The design itself is internally inconsistent; the diff is faithful but structurally broken.",
+    "diff_path": "fixtures/T-06-pre-amendment-faithful-impl.diff"
+  },
+  "expected": {
+    "verdict": "veto",
+    "findings": [
+      {
+        "severity": "CRITICAL",
+        "scope_check": 6,
+        "cited_section": ["§D3", "§D2"],
+        "evidence_pattern": "(?i)(BaseEntity|createdAt.*Date|createdBy|extends BaseRepository|Incident.*string)",
+        "description_pattern": "(?i)(does not satisfy|missing.*createdBy|missing.*createdAt|cannot.*compile|type contract|does not extend BaseEntity|ISO string.*Date)"
+      }
+    ]
+  },
+  "notes": "The adversarial seed: a clean-looking diff that faithfully implements the design and would superficially pass scope checks 1-5 (the BR/AC traceability looks intact, no silent design choices, the file map matches), yet is fundamentally broken because two cited statements in the same design section are mutually unsatisfiable. Without scope_check #6 the cold-reader has no rule to flag this. The fix is structural: cold-reader must check type-contract reachability between cited interfaces and cited contracts. Companion to the round-25 §D11 amend_design entry that fixed the underlying design defect."
+}

--- a/scripts/harness/evals/cold-reader/run.ts
+++ b/scripts/harness/evals/cold-reader/run.ts
@@ -34,7 +34,7 @@ interface ColdReaderCase {
     verdict: 'approve' | 'veto';
     findings: Array<{
       severity: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
-      scope_check: 1 | 2 | 3 | 4 | 5;
+      scope_check: 1 | 2 | 3 | 4 | 5 | 6;
       cited_section: string | string[];
       evidence_pattern: string;
       description_pattern: string;

--- a/scripts/harness/lib/prompts/builder.md
+++ b/scripts/harness/lib/prompts/builder.md
@@ -37,8 +37,8 @@ For every task:
 
 1. **Re-read** the cited spec/design sections. Do not trust your memory; do
    not infer from the task description alone.
-   1.5. **Pre-flight against project state** before any test is written. Two
-   checks, both mechanical:
+2. **Pre-flight against project state** before any test is written. Two
+   mechanical checks:
    - **Verify-line vs project pattern.** Does the verify line match the
      established test pattern for this file class? E.g. if the task says
      "unit tests against Firestore emulator" but every existing repo test
@@ -56,16 +56,16 @@ For every task:
      (b) emit `spec_gap` if the extension touches a surface beyond the
      immediate need or implies a verify-line amendment on the prior task.
      **Flag the choice in `notes`** so the cold-reader can see it.
-2. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
+3. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
    form. Run them; confirm they fail (RED).
-3. **Implement minimum code** to make the tests pass (GREEN). Avoid
+4. **Implement minimum code** to make the tests pass (GREEN). Avoid
    gold-plating.
-4. **Refactor.** Keep tests green.
-5. **Run the `Verify:` line literally.** It is the per-task gate.
-6. **Stage exactly the `allowed_writes` files.** No drive-by edits to
+5. **Refactor.** Keep tests green.
+6. **Run the `Verify:` line literally.** It is the per-task gate.
+7. **Stage exactly the `allowed_writes` files.** No drive-by edits to
    unrelated files. If you needed to touch something else, that's a
    `SPEC_GAP` — see drift escalation below.
-7. **Commit** with a message that cites at least one of the spec/design
+8. **Commit** with a message that cites at least one of the spec/design
    sections you just implemented. Format:
    `<type>(<scope>): <subject> (<citation>)`
    Example: `feat(incidents): activation FAB (BR-27, AC-18)`
@@ -89,7 +89,7 @@ exit instead of pushing through:
 - You discover a behavior the spec doesn't cover that is genuinely needed
   for the task to function.
 - **Two rules in this prompt itself conflict on this task.** Most commonly:
-  the TDD rule (#2 — "Write tests first; tests must assert the cited ACs")
+  the TDD rule (#3 — "Write tests first; tests must assert the cited ACs")
   presumes the task cites ACs and the verify line permits running tests
   against the produced code. If the task cites no ACs AND the verify line is
   structural (e.g. _"`tsc -b` passes with the new file imported nowhere"_),

--- a/scripts/harness/lib/prompts/builder.md
+++ b/scripts/harness/lib/prompts/builder.md
@@ -37,6 +37,25 @@ For every task:
 
 1. **Re-read** the cited spec/design sections. Do not trust your memory; do
    not infer from the task description alone.
+   1.5. **Pre-flight against project state** before any test is written. Two
+   checks, both mechanical:
+   - **Verify-line vs project pattern.** Does the verify line match the
+     established test pattern for this file class? E.g. if the task says
+     "unit tests against Firestore emulator" but every existing repo test
+     in `src/repositories/*.test.ts` uses `vi.mock('firebase/firestore')`,
+     that's a verify-line/pattern conflict — emit `spec_gap` so the
+     drift-arbiter can `amend_task`. **Do not silently switch patterns
+     either way.**
+   - **Layer-(N-1) surface availability.** If your task composes a
+     repository/service/hook that already exists, read its public surface
+     and confirm the methods/signatures the task assumes are present. If
+     the assumed surface is missing (e.g. you're a service task that needs
+     `repo.createWithId` but the repo only exposes `create`), you have two
+     options: (a) extend layer-(N-1) inside this task's PR as a paired
+     chore commit if the extension is mechanical and one-task-deep, or
+     (b) emit `spec_gap` if the extension touches a surface beyond the
+     immediate need or implies a verify-line amendment on the prior task.
+     **Flag the choice in `notes`** so the cold-reader can see it.
 2. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
    form. Run them; confirm they fail (RED).
 3. **Implement minimum code** to make the tests pass (GREEN). Avoid
@@ -97,6 +116,18 @@ You MUST NOT:
   That's a rule conflict — escalate per the trigger above.
 - Lie about Verify passing — if you cannot run it cleanly, that's a
   `verify_fail` exit, not a `success`.
+- **Invoke any infrastructure-deploy command as part of a verify gate.**
+  This includes (non-exhaustive): `firebase deploy`, `vercel deploy`,
+  `gcloud … deploy`, `kubectl apply`, `terraform apply`, any `deploy:*`
+  npm/pnpm script that targets a shared environment, any production
+  database migration runner. Verify gates must run against local emulators
+  (`firebase emulators:start --only firestore`), local servers, or the
+  in-process test runner. Deploys are post-merge human steps; if a task's
+  verify line names a deploy command, emit `spec_gap` and let the
+  drift-arbiter `amend_task` the verify line to an emulator/local
+  equivalent. Methodology basis: round-24 hit a 3-instance threshold
+  (T-01, T-04, T-03) on this exact pattern; this rule generalizes the
+  pattern.
 
 ---
 

--- a/scripts/harness/lib/prompts/cold-reader-code.md
+++ b/scripts/harness/lib/prompts/cold-reader-code.md
@@ -35,7 +35,7 @@ context.
 ## POSITIVE SCOPE (the only things you check for)
 
 For each finding you emit, the `scope_check` field MUST be one of these
-five numbers. If a concern doesn't fit one of these, do not emit it.
+six numbers. If a concern doesn't fit one of these, do not emit it.
 
 1. **Spec implementation correctness.** For each cited BR, trace the BR's
    text to a specific code line. If the diff doesn't implement what the BR
@@ -53,6 +53,20 @@ five numbers. If a concern doesn't fit one of these, do not emit it.
 5. **Hidden coupling.** Imports across feature boundaries that are not
    anticipated by the design §D2 file map. Cross-feature reach is MEDIUM
    unless it violates a cited NFR (then HIGH).
+6. **Type-contract conformance** (added round 25). When the design defines
+   a TypeScript interface AND a sibling instruction in the same design
+   section says the type extends or composes a project-wide contract
+   (`BaseEntity`, `Repository<T>`, `BaseRepository<T>`, etc.), check the
+   defined type against the cited contract's required members. If §D2
+   file map says `extends BaseRepository<Foo>` and §D3 defines
+   `interface Foo` that lacks `BaseEntity`'s required `createdAt: Date`,
+   `updatedAt: Date`, or `createdBy: string`, that is a CRITICAL
+   structural defect — the diff cannot compile against the cited
+   contract regardless of code. **You are not opining on type style;
+   you are checking whether two cited statements in the same design
+   section are mutually satisfiable.** Methodology basis: round-25
+   builder pre-flight caught this on T-06 after five rounds of design
+   cold-reads missed it.
 
 ---
 
@@ -100,7 +114,7 @@ comment thread.
   "findings": [
     {
       "severity": "CRITICAL" | "HIGH" | "MEDIUM",
-      "scope_check": 1 | 2 | 3 | 4 | 5,
+      "scope_check": 1 | 2 | 3 | 4 | 5 | 6,
       "cited_section": "BR-N" | "AC-M" | "§DN",
       "evidence": "<file>:<line> — <one short quote or summary>",
       "description": "<one paragraph, no opinion words>"


### PR DESCRIPTION
## Summary

Three findings logged across rounds 19–25 had hit promotion thresholds but were never converted into actual harness changes. Slice 1's first five tasks (PR #165, currently a draft) consumed test-corpus capacity to surface the same findings *again*, defeating the purpose. This PR ships them.

## What changed

**`scripts/harness/lib/prompts/builder.md`**
- New TDD step #2: **Pre-flight against project state** before any test is written. Two mechanical checks:
  - Verify-line vs project test-pattern conflict (round-24 + round-25 instance — emulator-vs-mocks).
  - Layer-(N-1) surface availability (round-25 — service expects repo surface not in repo's verify gate).
- New "You MUST NOT" rule: **never invoke infrastructure-deploy commands** as part of a verify gate. Methodology basis: round-24 hit a 3-instance threshold (T-01, T-04, T-03); generalizes the per-task pattern.

**`scripts/harness/lib/prompts/cold-reader-code.md`**
- Positive scope #6: **Type-contract conformance.** Cross-check that cited TS interfaces satisfy project-wide contracts referenced by sibling instructions in the same design section. Round-25 finding: five rounds of design cold-reads on §D3 missed that `Incident` did not satisfy `BaseEntity`. Six numbers replace five throughout.
- Type widened in `scripts/harness/evals/cold-reader/run.ts` and the README docstring.

**Eval fixtures**
- `builder/cases/regression/round-25-no-deploy-rule-spec-gap.{json,input.md}` — synthetic T-04 with verify line literally invoking `firebase deploy`. Expected: `status: spec_gap`. Builder regression bucket: 7 → 8.
- `cold-reader/cases/adversarial/round-25-type-contract-blind-spot.json` — first adversarial case in the cold-reader suite. Captures the round-25 #2 pattern: design instructs `extends BaseRepository<Incident>` while §D3 defines `Incident` lacking `BaseEntity` members. Expected: CRITICAL on `scope_check: 6`. Cold-reader adversarial bucket: 0 → 1.

Snapshots regenerated (`prepare-T-02`, `cold-read-T-01-no-diff` — both include the full prompt text, so the prompt diff is visible in the snapshot diff for review).

## Verify

- `pnpm exec tsc -b`: clean
- `pnpm run lint`: clean
- `pnpm run test:unit`: 866 / 1 skipped (no test changes; suite count matches main)
- `pnpm tsx scripts/harness/evals/cli-snapshots/run.ts`: 3/3 PASS
- `pnpm tsx scripts/harness/evals/builder/run.ts`: 8 cases load + validate
- `pnpm tsx scripts/harness/evals/cold-reader/run.ts`: 14 cases load + validate

## Carry-over

The cases validate at load time only. Live subagent dispatch lands in the next PR (controller wiring), at which point the fixtures here will execute end-to-end against the rebuilt prompts and the round-24/25 findings will have closed-loop test coverage.

## Test plan

- [ ] CI green (typecheck, lint, unit, integration, rules, snapshots)
- [ ] Reviewer reads the prompt diffs end-to-end (the snapshot diffs surface them)
- [ ] Confirm `cold-reader/run.ts` schema accepts both old (1-5) and new (6) `scope_check` values for case files