### PR TITLE
harness: wire subagent dispatch (build / review / arbitrate-run)

### DIFF
--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -1,0 +1,77 @@
+# Spec-Anchored Harness — CLI
+
+The harness orchestrates a 4-role pipeline (controller, builder, cold-reader, drift-arbiter) to drive a per-task TDD loop against a curated `03-tasks.md`. Architecture lives in `~/.claude/plans/i-want-to-explore-compressed-shannon.md`. Per-feature session log lives at `generate-spec-anchored-artifacts-log.md`.
+
+## Read-only commands (no LLM dispatch)
+
+```bash
+pnpm tsx scripts/harness/cli.ts status           # progress per slice + open DQs
+pnpm tsx scripts/harness/cli.ts next             # next actionable task
+pnpm tsx scripts/harness/cli.ts lint-commit FILE # validate citation in commit msg
+```
+
+## Render-only commands (prepare prompts for hand-paste)
+
+These commands build the role's full prompt + per-task input and write to stdout. Use when you want to inspect what a subagent would receive, or to feed it manually into a different harness.
+
+```bash
+pnpm tsx scripts/harness/cli.ts prepare T-11             # builder
+pnpm tsx scripts/harness/cli.ts cold-read T-11 --diff main..HEAD  # cold-reader
+pnpm tsx scripts/harness/cli.ts arbitrate gap.json       # drift-arbiter
+```
+
+## Subagent dispatch (live `claude -p` invocation)
+
+Spawns a fresh Claude Code subagent in a clean session, parses the structured exit per the role's contract, returns cost + duration + verdict.
+
+**Prerequisites:** `claude` CLI installed and authenticated (this is the same `claude` you use to start an interactive session). Subagents inherit your auth + plugins + settings.
+
+```bash
+# Builder — writes code, runs verify, commits. Requires acceptEdits permission.
+pnpm tsx scripts/harness/cli.ts build T-11
+
+# Cold-reader — read-only review of HEAD~1..HEAD diff against cited spec/design.
+pnpm tsx scripts/harness/cli.ts review T-11
+pnpm tsx scripts/harness/cli.ts review T-11 --diff main..HEAD
+
+# Drift-arbiter — resolves a spec_gap by amending spec/design/task or pushing back.
+pnpm tsx scripts/harness/cli.ts arbitrate-run gap.json
+```
+
+Each command supports `--json` for machine-readable output (suitable for piping into another tool).
+
+### Dispatch defaults
+
+| Role        | Model    | Permission mode    | Tool denials                                                                                                            | Timeout |
+| ----------- | -------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------- |
+| Builder     | `sonnet` | `acceptEdits`      | Bash deny on `firebase deploy`, `vercel deploy`, `gcloud`, `kubectl apply`, `terraform apply` (round-25 no-deploy rule) | 30 min  |
+| Cold-reader | `sonnet` | `plan` (read-only) | _none_                                                                                                                  | 10 min  |
+| Arbiter     | `sonnet` | `acceptEdits`      | Bash entirely (arbiter writes spec/design only, never runs commands)                                                    | 10 min  |
+
+Override via opts on `dispatchBuilder`/`dispatchColdReader`/`dispatchArbiter` if calling directly from TS.
+
+### Exit codes
+
+- `build`: 0 if `success`, 2 otherwise (`spec_gap` / `verify_fail` / `budget_exceeded`)
+- `review`: 0 if `approve`, 2 if `veto`
+- `arbitrate-run`: 0 always (the arbiter always returns a verdict; humans interpret)
+
+### State persistence
+
+Not yet implemented. Each dispatch is currently stateless — no `.harness/state.json`, no event log, no retry tracking across invocations. The next iteration will add an append-only event log so the controller can resume mid-slice and produce per-PR cost/duration reports.
+
+## Eval suites
+
+Per-role contract tests live in `scripts/harness/evals/`. Each suite is shape-validated at load time today; live subagent dispatch lands case-by-case.
+
+```bash
+pnpm tsx scripts/harness/evals/cli-snapshots/run.ts    # 3 prompt-render snapshots
+pnpm tsx scripts/harness/evals/builder/run.ts          # 8 builder cases
+pnpm tsx scripts/harness/evals/cold-reader/run.ts      # 14 cold-reader cases
+pnpm tsx scripts/harness/evals/drift-arbiter/run.ts    # 6 arbiter cases
+pnpm tsx scripts/harness/evals/parsers/run.ts          # 3 parser snapshots
+pnpm tsx scripts/harness/evals/citation-linter/run.ts  # 5 linter cases
+pnpm tsx scripts/harness/evals/integration/run.ts      # 1 cross-suite trajectory
+```
+
+When an intentional change to a role prompt or input renderer alters output, regenerate the affected snapshot per the suite's local README.

--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -39,6 +39,9 @@ import {
   type SpecGapPayload,
 } from './lib/drift-arbiter-input.ts';
 import { parseTaskList } from './lib/task-parser.ts';
+import { dispatchBuilder } from './lib/dispatch/builder-dispatch.ts';
+import { dispatchColdReader } from './lib/dispatch/cold-reader-dispatch.ts';
+import { dispatchArbiter } from './lib/dispatch/arbiter-dispatch.ts';
 import { dirname, join } from 'node:path';
 import { execSync } from 'node:child_process';
 
@@ -66,14 +69,22 @@ function usage(): string {
     '  arbitrate <spec-gap-file>  Render the drift-arbiter system prompt + per-',
     '                             arbitration input. <spec-gap-file> is a JSON',
     '                             file matching the SpecGapPayload shape.',
+    '  build <task-id>            Dispatch a builder subagent on the task. Uses',
+    '                             claude -p; returns the structured exit + cost.',
+    '  review <task-id>           Dispatch a cold-reader subagent on the task',
+    '                             diff. Use --diff for ref-range (default',
+    '                             HEAD~1..HEAD).',
+    '  arbitrate-run <spec-gap-file>',
+    '                             Dispatch a drift-arbiter subagent on the gap.',
     '',
     'Options:',
     `  --file <path>              Task list to read (default: ${DEFAULT_TASK_FILE}).`,
     '  --json                     Emit JSON instead of human-readable text.',
     '  --no-system-prompt         Render only the per-task input (omit prompt).',
-    '  --diff <ref-range>         For cold-read: git ref-range to diff (e.g.',
-    '                             `main..HEAD` or `<sha>~1..<sha>`). Defaults to',
-    '                             the current uncommitted diff (`git diff HEAD`).',
+    '  --diff <ref-range>         For cold-read / review: git ref-range to diff',
+    '                             (e.g. `main..HEAD`). Defaults to the current',
+    '                             uncommitted diff for cold-read and HEAD~1..HEAD',
+    '                             for review.',
     '  -h, --help                 Show this help.',
   ].join('\n');
 }
@@ -492,9 +503,191 @@ function main(): void {
       process.exit(input.missing_citations.length === 0 ? 0 : 2);
       break;
     }
+    case 'build': {
+      const taskId = positionals[1];
+      if (!taskId) {
+        fail('build requires a task id (e.g. T-11)\n\n' + usage());
+      }
+      void runBuild(taskId, filePath, fileArg, values.json).catch((err) => {
+        const reason = err instanceof Error ? err.message : String(err);
+        fail(`build dispatch failed: ${reason}`);
+      });
+      break;
+    }
+    case 'review': {
+      const taskId = positionals[1];
+      if (!taskId) {
+        fail('review requires a task id\n\n' + usage());
+      }
+      void runReview(taskId, filePath, fileArg, values.diff, values.json).catch(
+        (err) => {
+          const reason = err instanceof Error ? err.message : String(err);
+          fail(`review dispatch failed: ${reason}`);
+        }
+      );
+      break;
+    }
+    case 'arbitrate-run': {
+      const gapFile = positionals[1];
+      if (!gapFile) {
+        fail('arbitrate-run requires a spec_gap JSON file path\n\n' + usage());
+      }
+      void runArbitrate(gapFile, filePath, fileArg, values.json).catch(
+        (err) => {
+          const reason = err instanceof Error ? err.message : String(err);
+          fail(`arbitrate-run dispatch failed: ${reason}`);
+        }
+      );
+      break;
+    }
     default:
       fail(`unknown command '${command}'\n\n${usage()}`);
   }
+}
+
+async function runBuild(
+  taskId: string,
+  filePath: string,
+  fileArg: string,
+  json: boolean
+): Promise<void> {
+  process.stderr.write(
+    `harness: dispatching builder subagent for ${taskId} (this may take several minutes)...\n`
+  );
+  const { exit, raw } = await dispatchBuilder({
+    taskId,
+    taskListPath: filePath,
+  });
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          file: fileArg,
+          task_id: taskId,
+          exit,
+          cost_usd: raw.costUsd,
+          duration_ms: raw.durationMs,
+          num_turns: raw.numTurns,
+          session_id: raw.sessionId,
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    process.stdout.write(`builder exit: ${exit.status}\n`);
+    process.stdout.write(`  cost: $${raw.costUsd.toFixed(4)}\n`);
+    process.stdout.write(
+      `  duration: ${(raw.durationMs / 1000).toFixed(1)}s\n`
+    );
+    process.stdout.write(`  turns: ${raw.numTurns}\n`);
+    process.stdout.write(`  session: ${raw.sessionId}\n`);
+    if (exit.status === 'success' && exit.commit_sha) {
+      process.stdout.write(`  commit: ${exit.commit_sha}\n`);
+    }
+    if (exit.status === 'spec_gap') {
+      process.stdout.write(
+        `  cited: ${exit.cited_section}\n  gap: ${exit.gap_description}\n`
+      );
+    }
+    if (exit.status === 'verify_fail') {
+      process.stdout.write(
+        `  verify_command: ${exit.verify_command}\n  attempts: ${exit.attempts}\n`
+      );
+    }
+  }
+  process.exit(exit.status === 'success' ? 0 : 2);
+}
+
+async function runReview(
+  taskId: string,
+  filePath: string,
+  fileArg: string,
+  diffRange: string | undefined,
+  json: boolean
+): Promise<void> {
+  process.stderr.write(
+    `harness: dispatching cold-reader subagent for ${taskId}...\n`
+  );
+  const { exit, raw } = await dispatchColdReader({
+    taskId,
+    diffRange,
+    taskListPath: filePath,
+  });
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          file: fileArg,
+          task_id: taskId,
+          exit,
+          cost_usd: raw.costUsd,
+          duration_ms: raw.durationMs,
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    process.stdout.write(`cold-reader verdict: ${exit.verdict}\n`);
+    process.stdout.write(`  cost: $${raw.costUsd.toFixed(4)}\n`);
+    process.stdout.write(`  findings: ${exit.findings.length}\n`);
+    for (const finding of exit.findings) {
+      process.stdout.write(
+        `  - ${finding.severity} #${finding.scope_check} (${finding.cited_section}): ${finding.description.slice(0, 100)}\n`
+      );
+    }
+    if (exit.summary) {
+      process.stdout.write(`  summary: ${exit.summary}\n`);
+    }
+  }
+  process.exit(exit.verdict === 'approve' ? 0 : 2);
+}
+
+async function runArbitrate(
+  gapFile: string,
+  filePath: string,
+  fileArg: string,
+  json: boolean
+): Promise<void> {
+  const gapPath = resolve(process.cwd(), gapFile);
+  const raw = readFileSync(gapPath, 'utf8');
+  const specGap = JSON.parse(raw) as SpecGapPayload;
+  process.stderr.write(
+    `harness: dispatching arbiter subagent for ${specGap.task_id}...\n`
+  );
+  const { exit, raw: dispatchRaw } = await dispatchArbiter({
+    specGap,
+    taskListPath: filePath,
+  });
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          file: fileArg,
+          spec_gap: specGap,
+          exit,
+          cost_usd: dispatchRaw.costUsd,
+          duration_ms: dispatchRaw.durationMs,
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    process.stdout.write(`arbiter verdict: ${exit.verdict}\n`);
+    process.stdout.write(`  cost: $${dispatchRaw.costUsd.toFixed(4)}\n`);
+    if (exit.amended_section) {
+      process.stdout.write(`  amended: ${exit.amended_section}\n`);
+    }
+    if (exit.amendment_text) {
+      process.stdout.write(`  text: ${exit.amendment_text.slice(0, 200)}\n`);
+    }
+    if (exit.pushback_message) {
+      process.stdout.write(`  pushback: ${exit.pushback_message}\n`);
+    }
+  }
+  process.exit(0);
 }
 
 main();

--- a/scripts/harness/lib/dispatch/arbiter-dispatch.test.ts
+++ b/scripts/harness/lib/dispatch/arbiter-dispatch.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { parseArbiterExit } from './arbiter-dispatch';
+
+describe('parseArbiterExit', () => {
+  it('parses an amend_design verdict', () => {
+    const text = `\`\`\`json
+{
+  "verdict": "amend_design",
+  "amended_section": "§D6",
+  "amendment_text": "Add a Deferrals note covering chips and Spanish stubs.",
+  "changelog_entry": "2026-05-02 round 24 — added §D6 Deferrals note."
+}
+\`\`\``;
+    const exit = parseArbiterExit(text);
+    expect(exit.verdict).toBe('amend_design');
+    expect(exit.amended_section).toBe('§D6');
+  });
+
+  it('parses an amend_task verdict', () => {
+    const text =
+      '```json\n{"verdict":"amend_task","amended_section":"T-04","amendment_text":"emulator-only verify"}\n```';
+    expect(parseArbiterExit(text).verdict).toBe('amend_task');
+  });
+
+  it('parses an amend_spec verdict', () => {
+    const text =
+      '```json\n{"verdict":"amend_spec","amended_section":"BR-7","amendment_text":"clarify dedup-at-write"}\n```';
+    expect(parseArbiterExit(text).verdict).toBe('amend_spec');
+  });
+
+  it('parses a pushback verdict', () => {
+    const text =
+      '```json\n{"verdict":"pushback","pushback_message":"Builder misread; chips are out of T-05 scope per task notes."}\n```';
+    const exit = parseArbiterExit(text);
+    expect(exit.verdict).toBe('pushback');
+    expect(exit.pushback_message).toMatch(/misread/);
+  });
+
+  it('throws on invalid verdict', () => {
+    const text = '```json\n{"verdict":"reject_completely"}\n```';
+    expect(() => parseArbiterExit(text)).toThrow(/invalid verdict/);
+  });
+
+  it('throws when no parseable exit', () => {
+    expect(() => parseArbiterExit('plain prose nothing else')).toThrow();
+  });
+});

--- a/scripts/harness/lib/dispatch/arbiter-dispatch.ts
+++ b/scripts/harness/lib/dispatch/arbiter-dispatch.ts
@@ -1,0 +1,110 @@
+/**
+ * Drift-arbiter dispatcher.
+ *
+ * Spawns the arbiter subagent in `acceptEdits` permission mode (it can edit
+ * spec/design files) but with a tool deny on Bash to keep it from running
+ * commands. The arbiter is read-mostly; the only writes it should perform
+ * are to the cited spec/design files.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  buildDriftArbiterInput,
+  formatDriftArbiterInputMarkdown,
+  type SpecGapPayload,
+} from '../drift-arbiter-input';
+import { dispatchSubagent, type DispatchResult } from '../subagent-dispatch';
+import { parseStructuredExit } from './parse-structured-exit';
+import type { spawn as spawnType } from 'node:child_process';
+
+export type ArbiterVerdict =
+  | 'amend_spec'
+  | 'amend_design'
+  | 'amend_task'
+  | 'pushback';
+
+export interface ArbiterExit {
+  verdict: ArbiterVerdict;
+  amended_section?: string;
+  amendment_text?: string;
+  changelog_entry?: string;
+  pushback_message?: string;
+  notes?: string;
+}
+
+export interface ArbiterDispatchOptions {
+  specGap: SpecGapPayload;
+  taskListPath?: string;
+  promptPath?: string;
+  cwd?: string;
+  timeoutMs?: number;
+  spawnImpl?: typeof spawnType;
+}
+
+export interface ArbiterDispatchResult {
+  exit: ArbiterExit;
+  raw: DispatchResult;
+}
+
+const DEFAULT_TASK_LIST = 'docs/specs/incident-capture/03-tasks.md';
+const DEFAULT_PROMPT = 'scripts/harness/lib/prompts/drift-arbiter.md';
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+export async function dispatchArbiter(
+  opts: ArbiterDispatchOptions
+): Promise<ArbiterDispatchResult> {
+  const taskListPath = opts.taskListPath ?? DEFAULT_TASK_LIST;
+  const promptPath = opts.promptPath ?? DEFAULT_PROMPT;
+
+  const tasksMd = readFileSync(taskListPath, 'utf8');
+  const systemPrompt = readFileSync(promptPath, 'utf8');
+  const featureDir = dirname(taskListPath);
+  const specMd = readFileSync(join(featureDir, '01-spec.md'), 'utf8');
+  const designMd = readFileSync(join(featureDir, '02-design.md'), 'utf8');
+
+  const arbiterInput = buildDriftArbiterInput({
+    spec_gap: opts.specGap,
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+    tasksMarkdown: tasksMd,
+  });
+  const inputMd = formatDriftArbiterInputMarkdown(arbiterInput);
+
+  const fullPrompt = `${systemPrompt}\n\n---\n\n${inputMd}`;
+
+  const raw = await dispatchSubagent({
+    prompt: fullPrompt,
+    model: 'sonnet',
+    permissionMode: 'acceptEdits',
+    // Arbiter writes spec/design only, never runs commands.
+    disallowedTools: ['Bash'],
+    cwd: opts.cwd,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    spawnImpl: opts.spawnImpl,
+  });
+
+  const exit = parseArbiterExit(raw.resultText);
+  return { exit, raw };
+}
+
+export function parseArbiterExit(text: string): ArbiterExit {
+  const parsed = parseStructuredExit<Record<string, unknown>>(text);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(
+      `arbiter dispatch: could not parse structured exit. First 500 chars: ${text.slice(0, 500)}`
+    );
+  }
+  const verdict = parsed.verdict as string | undefined;
+  if (
+    verdict !== 'amend_spec' &&
+    verdict !== 'amend_design' &&
+    verdict !== 'amend_task' &&
+    verdict !== 'pushback'
+  ) {
+    throw new Error(
+      `arbiter dispatch: invalid verdict (got ${JSON.stringify(verdict)})`
+    );
+  }
+  return parsed as unknown as ArbiterExit;
+}

--- a/scripts/harness/lib/dispatch/builder-dispatch.test.ts
+++ b/scripts/harness/lib/dispatch/builder-dispatch.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { parseBuilderExit } from './builder-dispatch';
+
+describe('parseBuilderExit', () => {
+  it('parses success exit (JSON fenced)', () => {
+    const text =
+      '```json\n{"status":"success","commit_sha":"abc123","files_touched":["src/a.ts"]}\n```';
+    const exit = parseBuilderExit(text);
+    expect(exit.status).toBe('success');
+    if (exit.status === 'success') {
+      expect(exit.commit_sha).toBe('abc123');
+      expect(exit.files_touched).toEqual(['src/a.ts']);
+    }
+  });
+
+  it('parses spec_gap exit (YAML fenced)', () => {
+    const text = `here is the gap
+
+\`\`\`yaml
+status: spec_gap
+cited_section: BR-7
+gap_description: |
+  The BR is ambiguous on whether chips dedupe at write or read.
+suggested_amendment: |
+  Add to BR-7: dedupe at write per ChipId.
+\`\`\``;
+    const exit = parseBuilderExit(text);
+    expect(exit.status).toBe('spec_gap');
+    if (exit.status === 'spec_gap') {
+      expect(exit.cited_section).toBe('BR-7');
+      expect(exit.gap_description).toMatch(/ambiguous/);
+      expect(exit.suggested_amendment).toMatch(/dedupe at write/);
+    }
+  });
+
+  it('parses verify_fail exit (bare JSON)', () => {
+    const text =
+      '{"status":"verify_fail","verify_command":"pnpm run test","attempts":2}';
+    const exit = parseBuilderExit(text);
+    expect(exit.status).toBe('verify_fail');
+    if (exit.status === 'verify_fail') {
+      expect(exit.verify_command).toBe('pnpm run test');
+      expect(exit.attempts).toBe(2);
+    }
+  });
+
+  it('parses budget_exceeded exit', () => {
+    const text =
+      '```json\n{"status":"budget_exceeded","spent":{"tokens":100000},"last_action":"running tests"}\n```';
+    const exit = parseBuilderExit(text);
+    expect(exit.status).toBe('budget_exceeded');
+  });
+
+  it('throws on missing status', () => {
+    const text = '```json\n{"commit_sha":"abc"}\n```';
+    expect(() => parseBuilderExit(text)).toThrow(/status/);
+  });
+
+  it('throws on unrecognized status', () => {
+    const text = '```json\n{"status":"weird"}\n```';
+    expect(() => parseBuilderExit(text)).toThrow(/invalid status/);
+  });
+
+  it('throws when no structured exit can be parsed', () => {
+    expect(() => parseBuilderExit('just prose, nothing structured')).toThrow();
+  });
+});

--- a/scripts/harness/lib/dispatch/builder-dispatch.ts
+++ b/scripts/harness/lib/dispatch/builder-dispatch.ts
@@ -1,0 +1,165 @@
+/**
+ * Builder dispatcher.
+ *
+ * Loads the builder system prompt + per-task input, spawns a fresh
+ * `claude -p` subagent, and parses the structured exit per builder.md's
+ * output contract.
+ *
+ * The builder is configured with:
+ *   - model: sonnet (project default for the role)
+ *   - permissionMode: acceptEdits (it WILL write code + run verify + commit)
+ *   - disallowedTools: blanket Bash deny on infra-deploy commands as a
+ *     belt-and-suspenders backup to the round-25 builder.md no-deploy rule
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  buildBuilderInput,
+  formatBuilderInputMarkdown,
+} from '../builder-input';
+import { parseTaskList } from '../task-parser';
+import { dispatchSubagent, type DispatchResult } from '../subagent-dispatch';
+import { parseStructuredExit } from './parse-structured-exit';
+import type { spawn as spawnType } from 'node:child_process';
+
+export type BuilderStatus =
+  | 'success'
+  | 'spec_gap'
+  | 'verify_fail'
+  | 'budget_exceeded';
+
+export interface BuilderExitSuccess {
+  status: 'success';
+  commit_sha?: string;
+  files_touched?: string[];
+  verify_run?: Record<string, string>;
+  notes?: string;
+}
+
+export interface BuilderExitSpecGap {
+  status: 'spec_gap';
+  cited_section?: string;
+  gap_description?: string;
+  suggested_amendment?: string;
+  files_inspected?: string[];
+}
+
+export interface BuilderExitVerifyFail {
+  status: 'verify_fail';
+  verify_command?: string;
+  output_tail?: string;
+  attempts?: number;
+}
+
+export interface BuilderExitBudgetExceeded {
+  status: 'budget_exceeded';
+  spent?: Record<string, number>;
+  last_action?: string;
+}
+
+export type BuilderExit =
+  | BuilderExitSuccess
+  | BuilderExitSpecGap
+  | BuilderExitVerifyFail
+  | BuilderExitBudgetExceeded;
+
+export interface BuilderDispatchOptions {
+  taskId: string;
+  /** Task-list markdown override (defaults to incident-capture). */
+  taskListPath?: string;
+  /** Builder system prompt path (defaults to scripts/harness/lib/prompts/builder.md). */
+  promptPath?: string;
+  /** Override permission mode (default: acceptEdits). */
+  permissionMode?: 'acceptEdits' | 'bypassPermissions' | 'plan';
+  /** Override timeout (default: 30 minutes for builder). */
+  timeoutMs?: number;
+  /** Working directory for the subagent. */
+  cwd?: string;
+  /** Inject spawn for tests. */
+  spawnImpl?: typeof spawnType;
+}
+
+export interface BuilderDispatchResult {
+  exit: BuilderExit;
+  raw: DispatchResult;
+}
+
+const DEFAULT_TASK_LIST = 'docs/specs/incident-capture/03-tasks.md';
+const DEFAULT_PROMPT = 'scripts/harness/lib/prompts/builder.md';
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+// Belt-and-suspenders deny list to back up the no-deploy builder.md rule.
+// Any infra-deploy attempt fails at the tool-permission boundary even if the
+// model misreads its own system prompt. Names map to Claude Code Bash patterns.
+const DEFAULT_DISALLOWED_TOOLS = [
+  'Bash(firebase deploy:*)',
+  'Bash(vercel deploy:*)',
+  'Bash(vercel --prod:*)',
+  'Bash(gcloud:*)',
+  'Bash(kubectl apply:*)',
+  'Bash(terraform apply:*)',
+];
+
+export async function dispatchBuilder(
+  opts: BuilderDispatchOptions
+): Promise<BuilderDispatchResult> {
+  const taskListPath = opts.taskListPath ?? DEFAULT_TASK_LIST;
+  const promptPath = opts.promptPath ?? DEFAULT_PROMPT;
+
+  const taskListMd = readFileSync(taskListPath, 'utf8');
+  const systemPrompt = readFileSync(promptPath, 'utf8');
+  const featureDir = dirname(taskListPath);
+  const specMd = readFileSync(join(featureDir, '01-spec.md'), 'utf8');
+  const designMd = readFileSync(join(featureDir, '02-design.md'), 'utf8');
+
+  const parsed = parseTaskList(taskListMd);
+  const task = parsed.tasks.find((t) => t.id === opts.taskId);
+  if (!task) {
+    throw new Error(
+      `builder dispatch: task ${opts.taskId} not found in ${taskListPath}`
+    );
+  }
+  const builderInput = buildBuilderInput({
+    task,
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+  });
+  const inputMd = formatBuilderInputMarkdown(builderInput);
+
+  const fullPrompt = `${systemPrompt}\n\n---\n\n${inputMd}`;
+
+  const raw = await dispatchSubagent({
+    prompt: fullPrompt,
+    model: 'sonnet',
+    permissionMode: opts.permissionMode ?? 'acceptEdits',
+    disallowedTools: DEFAULT_DISALLOWED_TOOLS,
+    cwd: opts.cwd,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    spawnImpl: opts.spawnImpl,
+  });
+
+  const exit = parseBuilderExit(raw.resultText);
+  return { exit, raw };
+}
+
+export function parseBuilderExit(text: string): BuilderExit {
+  const parsed = parseStructuredExit<Record<string, unknown>>(text);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(
+      `builder dispatch: could not parse structured exit from response. First 500 chars: ${text.slice(0, 500)}`
+    );
+  }
+  const status = parsed.status as string | undefined;
+  if (
+    status !== 'success' &&
+    status !== 'spec_gap' &&
+    status !== 'verify_fail' &&
+    status !== 'budget_exceeded'
+  ) {
+    throw new Error(
+      `builder dispatch: missing or invalid status field (got ${JSON.stringify(status)})`
+    );
+  }
+  return parsed as unknown as BuilderExit;
+}

--- a/scripts/harness/lib/dispatch/cold-reader-dispatch.test.ts
+++ b/scripts/harness/lib/dispatch/cold-reader-dispatch.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { parseColdReaderExit } from './cold-reader-dispatch';
+
+describe('parseColdReaderExit', () => {
+  it('parses an approve verdict with empty findings', () => {
+    const text = `\`\`\`json
+{
+  "task_id": "T-06",
+  "verdict": "approve",
+  "findings": [],
+  "summary": "Clean implementation matches §D2/§D3."
+}
+\`\`\``;
+    const exit = parseColdReaderExit(text);
+    expect(exit.verdict).toBe('approve');
+    expect(exit.findings).toEqual([]);
+    expect(exit.task_id).toBe('T-06');
+  });
+
+  it('parses a veto with multiple findings', () => {
+    const text = `\`\`\`json
+{
+  "task_id": "T-05",
+  "verdict": "veto",
+  "findings": [
+    {
+      "severity": "HIGH",
+      "scope_check": 4,
+      "cited_section": "§D6",
+      "evidence": "src/locales/en/common.json — incidents.chips.* missing",
+      "description": "Design §D6 requires the full incidents subtree; chips omitted."
+    },
+    {
+      "severity": "HIGH",
+      "scope_check": 3,
+      "cited_section": "NFR-5",
+      "evidence": "src/locales/es/common.json — values are English",
+      "description": "Producer silently used English for Spanish entries."
+    }
+  ],
+  "summary": "Two HIGH on silent task-body deferrals."
+}
+\`\`\``;
+    const exit = parseColdReaderExit(text);
+    expect(exit.verdict).toBe('veto');
+    expect(exit.findings).toHaveLength(2);
+    expect(exit.findings[0]!.severity).toBe('HIGH');
+    expect(exit.findings[0]!.scope_check).toBe(4);
+    expect(exit.findings[1]!.cited_section).toBe('NFR-5');
+  });
+
+  it('throws on missing verdict', () => {
+    const text = '```json\n{"task_id":"T-1","findings":[]}\n```';
+    expect(() => parseColdReaderExit(text)).toThrow(/verdict/);
+  });
+
+  it('throws on invalid verdict', () => {
+    const text =
+      '```json\n{"task_id":"T-1","verdict":"maybe","findings":[]}\n```';
+    expect(() => parseColdReaderExit(text)).toThrow(/invalid verdict/);
+  });
+
+  it('treats missing findings as empty array', () => {
+    const text = '```json\n{"task_id":"T-1","verdict":"approve"}\n```';
+    const exit = parseColdReaderExit(text);
+    expect(exit.findings).toEqual([]);
+  });
+
+  it('throws when findings is not an array', () => {
+    const text =
+      '```json\n{"task_id":"T-1","verdict":"approve","findings":"none"}\n```';
+    expect(() => parseColdReaderExit(text)).toThrow(
+      /findings must be an array/
+    );
+  });
+});

--- a/scripts/harness/lib/dispatch/cold-reader-dispatch.ts
+++ b/scripts/harness/lib/dispatch/cold-reader-dispatch.ts
@@ -1,0 +1,136 @@
+/**
+ * Cold-reader dispatcher.
+ *
+ * Spawns the cold-reader subagent in `plan` permission mode (read-only) and
+ * parses the verdict + findings JSON per cold-reader-code.md.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { execSync } from 'node:child_process';
+import {
+  buildColdReaderInput,
+  formatColdReaderInputMarkdown,
+} from '../cold-reader-input';
+import { parseTaskList } from '../task-parser';
+import { dispatchSubagent, type DispatchResult } from '../subagent-dispatch';
+import { parseStructuredExit } from './parse-structured-exit';
+import type { spawn as spawnType } from 'node:child_process';
+
+export type ColdReaderVerdict = 'approve' | 'veto';
+export type ColdReaderSeverity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
+
+export interface ColdReaderFinding {
+  severity: ColdReaderSeverity;
+  scope_check: 1 | 2 | 3 | 4 | 5 | 6;
+  cited_section: string;
+  evidence: string;
+  description: string;
+}
+
+export interface ColdReaderExit {
+  task_id: string;
+  verdict: ColdReaderVerdict;
+  findings: ColdReaderFinding[];
+  summary?: string;
+  notes?: string;
+}
+
+export interface ColdReaderDispatchOptions {
+  taskId: string;
+  /** Git ref-range to diff (default: HEAD~1..HEAD). */
+  diffRange?: string;
+  taskListPath?: string;
+  promptPath?: string;
+  cwd?: string;
+  timeoutMs?: number;
+  spawnImpl?: typeof spawnType;
+}
+
+export interface ColdReaderDispatchResult {
+  exit: ColdReaderExit;
+  raw: DispatchResult;
+}
+
+const DEFAULT_TASK_LIST = 'docs/specs/incident-capture/03-tasks.md';
+const DEFAULT_PROMPT = 'scripts/harness/lib/prompts/cold-reader-code.md';
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+export async function dispatchColdReader(
+  opts: ColdReaderDispatchOptions
+): Promise<ColdReaderDispatchResult> {
+  const taskListPath = opts.taskListPath ?? DEFAULT_TASK_LIST;
+  const promptPath = opts.promptPath ?? DEFAULT_PROMPT;
+  const diffRange = opts.diffRange ?? 'HEAD~1..HEAD';
+
+  const taskListMd = readFileSync(taskListPath, 'utf8');
+  const systemPrompt = readFileSync(promptPath, 'utf8');
+  const featureDir = dirname(taskListPath);
+  const specMd = readFileSync(join(featureDir, '01-spec.md'), 'utf8');
+  const designMd = readFileSync(join(featureDir, '02-design.md'), 'utf8');
+
+  const diff = readGitDiff(diffRange, opts.cwd);
+
+  const parsed = parseTaskList(taskListMd);
+  const task = parsed.tasks.find((t) => t.id === opts.taskId);
+  if (!task) {
+    throw new Error(`cold-reader dispatch: task ${opts.taskId} not found`);
+  }
+  const crInput = buildColdReaderInput({
+    task,
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+    diff,
+  });
+  const inputMd = formatColdReaderInputMarkdown(crInput);
+
+  const fullPrompt = `${systemPrompt}\n\n---\n\n${inputMd}`;
+
+  const raw = await dispatchSubagent({
+    prompt: fullPrompt,
+    model: 'sonnet',
+    permissionMode: 'plan',
+    cwd: opts.cwd,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    spawnImpl: opts.spawnImpl,
+  });
+
+  const exit = parseColdReaderExit(raw.resultText);
+  return { exit, raw };
+}
+
+function readGitDiff(range: string, cwd?: string): string {
+  return execSync(`git diff ${range}`, {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+export function parseColdReaderExit(text: string): ColdReaderExit {
+  const parsed = parseStructuredExit<Record<string, unknown>>(text);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(
+      `cold-reader dispatch: could not parse structured exit. First 500 chars: ${text.slice(0, 500)}`
+    );
+  }
+  const verdict = parsed.verdict as string | undefined;
+  if (verdict !== 'approve' && verdict !== 'veto') {
+    throw new Error(
+      `cold-reader dispatch: invalid verdict (got ${JSON.stringify(verdict)})`
+    );
+  }
+  const findings = (parsed.findings ?? []) as ColdReaderFinding[];
+  if (!Array.isArray(findings)) {
+    throw new Error(
+      `cold-reader dispatch: findings must be an array (got ${typeof findings})`
+    );
+  }
+  return {
+    task_id: String(parsed.task_id ?? ''),
+    verdict,
+    findings,
+    summary: parsed.summary as string | undefined,
+    notes: parsed.notes as string | undefined,
+  };
+}

--- a/scripts/harness/lib/dispatch/parse-structured-exit.test.ts
+++ b/scripts/harness/lib/dispatch/parse-structured-exit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractFencedBlock,
+  parseFlatYaml,
+  parseStructuredExit,
+  tryParseJson,
+} from './parse-structured-exit';
+
+describe('extractFencedBlock', () => {
+  it('extracts a json fenced block', () => {
+    const text = 'preamble\n```json\n{"a":1}\n```\nepilogue';
+    expect(extractFencedBlock(text)).toEqual({
+      format: 'json',
+      body: '{"a":1}',
+    });
+  });
+
+  it('extracts a yaml fenced block when no json present', () => {
+    const text = '```yaml\nstatus: success\n```';
+    expect(extractFencedBlock(text)).toEqual({
+      format: 'yaml',
+      body: 'status: success',
+    });
+  });
+
+  it('prefers json when both present', () => {
+    const text = '```yaml\nfoo: 1\n```\n```json\n{"b":2}\n```';
+    expect(extractFencedBlock(text)).toEqual({
+      format: 'json',
+      body: '{"b":2}',
+    });
+  });
+
+  it('returns null when no fence', () => {
+    expect(extractFencedBlock('just prose, no fence')).toBeNull();
+  });
+});
+
+describe('tryParseJson', () => {
+  it('parses valid JSON', () => {
+    expect(tryParseJson('{"x":1}')).toEqual({ x: 1 });
+  });
+
+  it('returns null on invalid JSON', () => {
+    expect(tryParseJson('{not json}')).toBeNull();
+  });
+});
+
+describe('parseFlatYaml', () => {
+  it('parses simple key: value', () => {
+    const y = `status: success\ncommit_sha: abc123`;
+    expect(parseFlatYaml(y)).toEqual({
+      status: 'success',
+      commit_sha: 'abc123',
+    });
+  });
+
+  it('parses block scalars (|)', () => {
+    const y = `status: spec_gap\ngap_description: |\n  This is a multi-line\n  description.\nsuggested_amendment: |\n  one line`;
+    const parsed = parseFlatYaml(y);
+    expect(parsed.status).toBe('spec_gap');
+    expect(parsed.gap_description).toBe('This is a multi-line\ndescription.');
+    expect(parsed.suggested_amendment).toBe('one line');
+  });
+
+  it('parses lists', () => {
+    const y = `status: success\nfiles_touched:\n  - src/a.ts\n  - src/b.ts`;
+    const parsed = parseFlatYaml(y);
+    expect(parsed.status).toBe('success');
+    expect(parsed.files_touched).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('parses nested maps', () => {
+    const y = `status: success\nverify_run:\n  typecheck: pass\n  lint: pass\n  test: pass`;
+    const parsed = parseFlatYaml(y);
+    expect(parsed.verify_run).toEqual({
+      typecheck: 'pass',
+      lint: 'pass',
+      test: 'pass',
+    });
+  });
+
+  it('strips wrapping quotes on string values', () => {
+    expect(parseFlatYaml('a: "hello"\nb: \'world\'')).toEqual({
+      a: 'hello',
+      b: 'world',
+    });
+  });
+});
+
+describe('parseStructuredExit', () => {
+  it('returns parsed JSON from a fenced json block', () => {
+    const text =
+      'sure, here it is:\n```json\n{"verdict":"approve","findings":[]}\n```';
+    expect(parseStructuredExit(text)).toEqual({
+      verdict: 'approve',
+      findings: [],
+    });
+  });
+
+  it('returns parsed YAML when only YAML fence present', () => {
+    const text = '```yaml\nstatus: success\ncommit_sha: abc\n```';
+    expect(parseStructuredExit(text)).toEqual({
+      status: 'success',
+      commit_sha: 'abc',
+    });
+  });
+
+  it('falls back to bare JSON when no fence', () => {
+    const text = '{"status":"verify_fail","attempts":2}';
+    expect(parseStructuredExit(text)).toEqual({
+      status: 'verify_fail',
+      attempts: 2,
+    });
+  });
+
+  it('returns the YAML structure for bare YAML when no fence and not JSON', () => {
+    const text = 'status: success\ncommit_sha: deadbeef';
+    expect(parseStructuredExit(text)).toEqual({
+      status: 'success',
+      commit_sha: 'deadbeef',
+    });
+  });
+});

--- a/scripts/harness/lib/dispatch/parse-structured-exit.ts
+++ b/scripts/harness/lib/dispatch/parse-structured-exit.ts
@@ -1,0 +1,160 @@
+/**
+ * Parse a subagent's final text response into a structured exit payload.
+ *
+ * Builder, cold-reader, and arbiter prompts all instruct the subagent to
+ * emit a structured exit (JSON or, for builder, optionally YAML). This
+ * parser is permissive about wrapping (fenced code block or bare) and
+ * format (prefers JSON; falls back to a minimal flat-key YAML reader).
+ *
+ * Returns `null` when nothing parseable is found — callers decide whether
+ * that's a failure or a permission to fall back.
+ */
+
+export function extractFencedBlock(
+  text: string,
+  prefer: ('json' | 'yaml')[] = ['json', 'yaml']
+): { format: 'json' | 'yaml'; body: string } | null {
+  for (const lang of prefer) {
+    const re = new RegExp('```' + lang + '\\s*\\n([\\s\\S]*?)\\n\\s*```', 'i');
+    const m = re.exec(text);
+    if (m && m[1] !== undefined) {
+      return { format: lang, body: m[1].trim() };
+    }
+  }
+  return null;
+}
+
+export function tryParseJson<T = unknown>(body: string): T | null {
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Minimal flat-key YAML parser for the known exit shapes:
+ *   key: value
+ *   key: |
+ *     multi-line value
+ *   key:
+ *     - list item
+ *     - list item
+ *   key:
+ *     nested_key: value
+ *
+ * Not a full YAML parser. Just enough for builder/cold-reader/arbiter exits.
+ * Returns a plain object with string / string[] / nested-object values.
+ */
+export function parseFlatYaml(body: string): Record<string, unknown> {
+  const lines = body.split('\n');
+  const result: Record<string, unknown> = {};
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent !== 0 || line.trim() === '' || line.trim().startsWith('#')) {
+      i++;
+      continue;
+    }
+    const m = /^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/.exec(line);
+    if (!m) {
+      i++;
+      continue;
+    }
+    const key = m[1]!;
+    const inlineValue = m[2]!.trim();
+    if (inlineValue === '|' || inlineValue === '>') {
+      // Block scalar — collect indented continuation.
+      const block: string[] = [];
+      i++;
+      while (i < lines.length) {
+        const next = lines[i]!;
+        const nextIndent = next.match(/^ */)?.[0].length ?? 0;
+        if (next.trim() === '' && i + 1 < lines.length) {
+          block.push('');
+          i++;
+          continue;
+        }
+        if (nextIndent < 2) break;
+        block.push(next.slice(2));
+        i++;
+      }
+      result[key] = block.join('\n').trim();
+      continue;
+    }
+    if (inlineValue === '') {
+      // Either a list or a nested map starting on next lines.
+      const block: string[] = [];
+      const nested: Record<string, string> = {};
+      i++;
+      let mode: 'list' | 'map' | 'unknown' = 'unknown';
+      while (i < lines.length) {
+        const next = lines[i]!;
+        const nextIndent = next.match(/^ */)?.[0].length ?? 0;
+        if (next.trim() === '') {
+          i++;
+          continue;
+        }
+        if (nextIndent === 0) break;
+        const stripped = next.trim();
+        if (stripped.startsWith('-')) {
+          mode = 'list';
+          block.push(stripped.slice(1).trim());
+        } else {
+          const sub = /^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/.exec(stripped);
+          if (sub) {
+            mode = 'map';
+            nested[sub[1]!] = sub[2]!.trim();
+          }
+        }
+        i++;
+      }
+      if (mode === 'list') {
+        result[key] = block;
+      } else if (mode === 'map') {
+        result[key] = nested;
+      } else {
+        result[key] = '';
+      }
+      continue;
+    }
+    result[key] = stripQuotes(inlineValue);
+    i++;
+  }
+  return result;
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Top-level extractor: finds a fenced JSON or YAML block and returns the
+ * parsed structured exit. Falls back to parsing the entire text as JSON
+ * (then bare YAML) if no fence is found.
+ */
+export function parseStructuredExit<T = Record<string, unknown>>(
+  text: string
+): T | null {
+  const fenced = extractFencedBlock(text);
+  if (fenced) {
+    if (fenced.format === 'json') {
+      const parsed = tryParseJson<T>(fenced.body);
+      if (parsed !== null) return parsed;
+    }
+    if (fenced.format === 'yaml') {
+      return parseFlatYaml(fenced.body) as T;
+    }
+  }
+  const bareJson = tryParseJson<T>(text.trim());
+  if (bareJson !== null) return bareJson;
+  // Last resort: try YAML on the whole text.
+  return parseFlatYaml(text) as T;
+}

--- a/scripts/harness/lib/subagent-dispatch.test.ts
+++ b/scripts/harness/lib/subagent-dispatch.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import { dispatchSubagent } from './subagent-dispatch';
+
+interface FakeChild extends EventEmitter {
+  stdin: Writable;
+  stdout: Readable;
+  stderr: Readable;
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeFakeChild(opts: {
+  stdoutChunks?: string[];
+  stderrChunks?: string[];
+  exitCode: number | null;
+  exitDelayMs?: number;
+}): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+
+  const stdinChunks: string[] = [];
+  child.stdin = new Writable({
+    write(chunk, _encoding, cb) {
+      stdinChunks.push(chunk.toString());
+      cb();
+    },
+    final(cb) {
+      cb();
+    },
+  });
+
+  child.stdout = Readable.from((opts.stdoutChunks ?? []).map(Buffer.from));
+  child.stderr = Readable.from((opts.stderrChunks ?? []).map(Buffer.from));
+
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  child.killed = false;
+
+  setTimeout(() => {
+    child.emit('exit', opts.exitCode);
+  }, opts.exitDelayMs ?? 5);
+
+  return child;
+}
+
+const VALID_ENVELOPE = JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  result: '{"status":"success","commit_sha":"abc123"}',
+  stop_reason: 'end_turn',
+  session_id: 'session-1',
+  total_cost_usd: 0.42,
+  duration_ms: 1234,
+  num_turns: 3,
+});
+
+describe('dispatchSubagent', () => {
+  it('builds claude args with the expected defaults', async () => {
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: [VALID_ENVELOPE], exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await dispatchSubagent({
+      prompt: 'hello',
+      spawnImpl,
+    });
+
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    const call = (spawnImpl as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(call[0]).toBe('claude');
+    expect(call[1]).toEqual([
+      '-p',
+      '--output-format',
+      'json',
+      '--model',
+      'sonnet',
+    ]);
+  });
+
+  it('passes permission-mode, allowed/disallowed tools, and append-system-prompt through', async () => {
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: [VALID_ENVELOPE], exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await dispatchSubagent({
+      prompt: 'hi',
+      model: 'haiku',
+      permissionMode: 'plan',
+      allowedTools: ['Read', 'Grep'],
+      disallowedTools: ['Bash(firebase deploy)'],
+      appendSystemPrompt: 'extra',
+      spawnImpl,
+    });
+
+    const args = (spawnImpl as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as string[];
+    expect(args).toContain('--model');
+    expect(args).toContain('haiku');
+    expect(args).toContain('--permission-mode');
+    expect(args).toContain('plan');
+    expect(args).toContain('--allowedTools');
+    expect(args).toContain('Read');
+    expect(args).toContain('Grep');
+    expect(args).toContain('--disallowedTools');
+    expect(args).toContain('Bash(firebase deploy)');
+    expect(args).toContain('--append-system-prompt');
+    expect(args).toContain('extra');
+  });
+
+  it('parses the JSON envelope and returns structured fields', async () => {
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: [VALID_ENVELOPE], exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await dispatchSubagent({ prompt: 'go', spawnImpl });
+
+    expect(result.resultText).toBe(
+      '{"status":"success","commit_sha":"abc123"}'
+    );
+    expect(result.isError).toBe(false);
+    expect(result.costUsd).toBe(0.42);
+    expect(result.durationMs).toBe(1234);
+    expect(result.numTurns).toBe(3);
+    expect(result.sessionId).toBe('session-1');
+    expect(result.stopReason).toBe('end_turn');
+  });
+
+  it('marks isError=true when claude reports is_error in the envelope', async () => {
+    const errorEnvelope = JSON.stringify({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      result: 'something went wrong',
+      stop_reason: 'tool_use',
+      session_id: 's',
+      total_cost_usd: 0,
+      duration_ms: 0,
+      num_turns: 0,
+    });
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: [errorEnvelope], exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await dispatchSubagent({ prompt: 'go', spawnImpl });
+    expect(result.isError).toBe(true);
+  });
+
+  it('throws when stdout has no parseable envelope and exit was non-zero', async () => {
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({
+        stdoutChunks: [],
+        stderrChunks: ['boom'],
+        exitCode: 1,
+      })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await expect(dispatchSubagent({ prompt: 'go', spawnImpl })).rejects.toThrow(
+      /exited with code 1/
+    );
+  });
+
+  it('throws when stdout has content but no parseable envelope', async () => {
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({
+        stdoutChunks: ['some warning\nnot json\n'],
+        exitCode: 0,
+      })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await expect(dispatchSubagent({ prompt: 'go', spawnImpl })).rejects.toThrow(
+      /result envelope/
+    );
+  });
+
+  it('writes the prompt to the child stdin', async () => {
+    let captured = '';
+    const child = makeFakeChild({
+      stdoutChunks: [VALID_ENVELOPE],
+      exitCode: 0,
+    });
+    child.stdin = new Writable({
+      write(chunk, _encoding, cb) {
+        captured += chunk.toString();
+        cb();
+      },
+      final(cb) {
+        cb();
+      },
+    });
+    const spawnImpl = vi.fn(
+      () => child
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await dispatchSubagent({ prompt: 'the-prompt-text', spawnImpl });
+
+    expect(captured).toBe('the-prompt-text');
+  });
+});

--- a/scripts/harness/lib/subagent-dispatch.ts
+++ b/scripts/harness/lib/subagent-dispatch.ts
@@ -1,0 +1,200 @@
+/**
+ * Generic subagent dispatch wrapper.
+ *
+ * Spawns a fresh `claude -p` subagent with the given prompt + options and
+ * returns the parsed result envelope. The envelope is shape-stable across
+ * Claude Code versions per `--output-format json` contract:
+ *
+ *   {
+ *     "type": "result",
+ *     "subtype": "success" | "error_during_execution" | ...,
+ *     "is_error": boolean,
+ *     "result": "<assistant's final text response>",
+ *     "stop_reason": "end_turn" | "max_turns" | ...,
+ *     "session_id": "<uuid>",
+ *     "total_cost_usd": number,
+ *     "duration_ms": number,
+ *     "num_turns": number,
+ *     "usage": { ... }
+ *   }
+ *
+ * The role-specific dispatchers (builder, cold-reader, arbiter) call this
+ * and then parse `resultText` for their respective structured exits.
+ *
+ * Pure relative to the spawn boundary — testable by mocking node:child_process.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+
+export type ClaudeModel = 'opus' | 'sonnet' | 'haiku';
+export type PermissionMode =
+  | 'acceptEdits'
+  | 'plan'
+  | 'bypassPermissions'
+  | 'default';
+
+export interface DispatchOptions {
+  /** The prompt text passed to the subagent (the per-role system prompt + per-task input, already concatenated by the caller). */
+  prompt: string;
+  /** Model alias. Defaults to `sonnet` (the harness's standard role model). */
+  model?: ClaudeModel;
+  /** Permission mode for the subagent. Builder typically `acceptEdits`; cold-reader/arbiter typically `plan`. */
+  permissionMode?: PermissionMode;
+  /** Optional allowlist of tools (passed verbatim to `claude --allowedTools`). */
+  allowedTools?: string[];
+  /** Optional denylist of tools. Forbidden-deploy enforcement lives here. */
+  disallowedTools?: string[];
+  /** Working directory for the subagent. Defaults to the parent process cwd. */
+  cwd?: string;
+  /** Hard wall-clock cap. Subagent is killed on timeout. Default 15 min. */
+  timeoutMs?: number;
+  /** Optional appended system prompt (kept separate from the per-task input). */
+  appendSystemPrompt?: string;
+  /** Optional per-call extra args passed verbatim to claude. */
+  extraArgs?: string[];
+  /** For tests: inject a spawn implementation. */
+  spawnImpl?: typeof spawn;
+}
+
+export interface DispatchResult {
+  /** The assistant's final text response. The role dispatcher parses this further. */
+  resultText: string;
+  /** True if the subagent exited with `is_error: true` or non-zero code. */
+  isError: boolean;
+  /** USD cost. */
+  costUsd: number;
+  /** Wall-clock duration ms (per claude's own measurement). */
+  durationMs: number;
+  /** Number of assistant turns. */
+  numTurns: number;
+  /** Subagent session id (for log correlation). */
+  sessionId: string;
+  /** Stop reason from the model. */
+  stopReason: string;
+  /** Raw envelope, for debugging / structured logging. */
+  rawEnvelope: unknown;
+}
+
+interface ClaudeJsonEnvelope {
+  type: 'result';
+  subtype: string;
+  is_error: boolean;
+  result: string;
+  stop_reason: string;
+  session_id: string;
+  total_cost_usd: number;
+  duration_ms: number;
+  num_turns: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+
+export async function dispatchSubagent(
+  opts: DispatchOptions
+): Promise<DispatchResult> {
+  const args = buildClaudeArgs(opts);
+  const spawner = opts.spawnImpl ?? spawn;
+  const child: ChildProcess = spawner('claude', args, {
+    cwd: opts.cwd,
+    env: process.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  // Pass the prompt over stdin — avoids ARG_MAX limits and shell escaping.
+  child.stdin?.write(opts.prompt);
+  child.stdin?.end();
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString('utf8');
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutHandle = setTimeout(() => {
+    child.kill('SIGTERM');
+  }, timeoutMs);
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    child.on('exit', (code) => resolve(code));
+  });
+  clearTimeout(timeoutHandle);
+
+  if (exitCode !== 0 && !stdout.trim()) {
+    throw new Error(
+      `claude subagent exited with code ${exitCode} and no stdout. stderr: ${stderr.trim().slice(0, 500)}`
+    );
+  }
+
+  const envelope = parseEnvelope(stdout);
+
+  return {
+    resultText: envelope.result,
+    isError: envelope.is_error || exitCode !== 0,
+    costUsd: envelope.total_cost_usd,
+    durationMs: envelope.duration_ms,
+    numTurns: envelope.num_turns,
+    sessionId: envelope.session_id,
+    stopReason: envelope.stop_reason,
+    rawEnvelope: envelope,
+  };
+}
+
+/**
+ * Receives a prompt argument that is fed via stdin. The `-p` flag is
+ * still passed (no following positional) to put claude into print mode.
+ */
+function buildClaudeArgs(opts: DispatchOptions): string[] {
+  const args = ['-p', '--output-format', 'json'];
+
+  args.push('--model', opts.model ?? 'sonnet');
+  if (opts.permissionMode) {
+    args.push('--permission-mode', opts.permissionMode);
+  }
+  if (opts.allowedTools && opts.allowedTools.length > 0) {
+    args.push('--allowedTools', ...opts.allowedTools);
+  }
+  if (opts.disallowedTools && opts.disallowedTools.length > 0) {
+    args.push('--disallowedTools', ...opts.disallowedTools);
+  }
+  if (opts.appendSystemPrompt) {
+    args.push('--append-system-prompt', opts.appendSystemPrompt);
+  }
+  if (opts.extraArgs && opts.extraArgs.length > 0) {
+    args.push(...opts.extraArgs);
+  }
+  return args;
+}
+
+function parseEnvelope(stdout: string): ClaudeJsonEnvelope {
+  // claude -p --output-format json emits one JSON object on stdout. If the
+  // stream included other lines (warnings, etc.) take the last well-formed
+  // JSON line.
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!;
+    if (line.startsWith('{') && line.endsWith('}')) {
+      try {
+        const parsed = JSON.parse(line) as Partial<ClaudeJsonEnvelope>;
+        if (
+          parsed.type === 'result' &&
+          typeof parsed.result === 'string' &&
+          typeof parsed.is_error === 'boolean'
+        ) {
+          return parsed as ClaudeJsonEnvelope;
+        }
+      } catch {
+        // try next line
+      }
+    }
+  }
+  throw new Error(
+    `claude stdout did not contain a parseable result envelope. First 500 chars: ${stdout.slice(0, 500)}`
+  );
+}


### PR DESCRIPTION
## Summary

Replaces hand-paste with `claude -p` automation for all three subagent roles. Slice 1's first five tasks were hand-built because no dispatch existed; this PR closes that gap so T-11..T-16 (and future slices) run **through** the rebuilt prompts (PR #166), not around them.

## What's new

### Generic dispatch primitive

`scripts/harness/lib/subagent-dispatch.ts` — wraps `claude -p --output-format json`. Pipes the prompt over stdin to dodge ARG_MAX, parses the JSON envelope, returns typed result + cost/duration/session metadata. Spawn injectable for testing.

### Structured-exit parser

`scripts/harness/lib/dispatch/parse-structured-exit.ts` — permissive parser for the role exits. Prefers fenced ` ```json `, falls back to fenced ` ```yaml `, then bare JSON, then a minimal flat-key YAML reader for the known shapes (block scalars, lists, nested maps). 15 unit tests.

### Three role dispatchers

| Role | File | Permission mode | Tool denials | Timeout |
|------|------|-----------------|--------------|---------|
| Builder | `lib/dispatch/builder-dispatch.ts` | `acceptEdits` | Bash deny on `firebase deploy`, `vercel deploy`, `gcloud`, `kubectl apply`, `terraform apply` (round-25 no-deploy rule's belt-and-suspenders backup) | 30 min |
| Cold-reader | `lib/dispatch/cold-reader-dispatch.ts` | `plan` (read-only) | _none_ | 10 min |
| Arbiter | `lib/dispatch/arbiter-dispatch.ts` | `acceptEdits` | Bash entirely (arbiter writes spec/design only) | 10 min |

Each parses its own structured exit per the role's contract. 19 unit tests across the three.

### Three new CLI commands

```bash
pnpm tsx scripts/harness/cli.ts build T-11             # dispatch builder
pnpm tsx scripts/harness/cli.ts review T-11 [--diff]   # dispatch cold-reader
pnpm tsx scripts/harness/cli.ts arbitrate-run gap.json # dispatch arbiter
```

Mirror the existing render-only triple (`prepare`, `cold-read`, `arbitrate`). All support `--json`. Exit codes match per-role semantics.

### README

`scripts/harness/README.md` — first README for the harness. Covers read-only commands, render-only commands, dispatch commands, dispatch defaults table, exit codes, eval suites.

## What this unblocks

PR #165 (slice 1 partial, T-06..T-10) can now resume with T-11..T-16 dispatched through the harness, generating real cost/duration data and exercising the round-24/25 methodology amendments shipped in PR #166.

## Verify

- `pnpm exec tsc -b`: clean
- `pnpm run lint`: clean
- `pnpm run test:unit`: **906 / 1 skipped** (was 866 on main; +40 from dispatch tests)
- `pnpm tsx scripts/harness/evals/cli-snapshots/run.ts`: 3/3 PASS
- `pnpm tsx scripts/harness/cli.ts --help`: lists all 9 commands

## Not in this PR (intentional)

- **State persistence.** No `.harness/state.json` event log yet; each dispatch is stateless. Follow-up.
- **Live e2e in CI.** Burning tokens on every push isn't worth it. Smoke-tested locally via `claude -p "say only OK" --output-format json` to confirm envelope shape; the parser is exercised against canned envelopes in tests.
- **The controller loop.** This PR ships the dispatch primitive. The orchestration loop (builder → cold-reader → arbiter on gap → re-dispatch builder) is its own follow-up; the per-role commands here are the building blocks.

## Test plan

- [ ] CI green
- [ ] Reviewer reads the dispatcher contracts (the three `*-dispatch.ts` files)
- [ ] Reviewer confirms the deny lists in `builder-dispatch.ts` cover the project's deploy surface
- [ ] After merge: pick one slice 1 remaining task (T-11..T-15) and run `pnpm tsx scripts/harness/cli.ts build <id>` to validate live dispatch end-to-end before resuming PR #165