### PR TITLE
harness: round-27 dispatcher resilience + first live verify_fail fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ package-lock.json
 test_output.txt
 test-output.json
 DELETE-ME.txt
+
+# Harness runtime state (round-26 architecture plan §1)
+.harness/

--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -554,7 +554,7 @@ async function runBuild(
   process.stderr.write(
     `harness: dispatching builder subagent for ${taskId} (this may take several minutes)...\n`
   );
-  const { exit, raw } = await dispatchBuilder({
+  const { exit, raw, parseError } = await dispatchBuilder({
     taskId,
     taskListPath: filePath,
   });
@@ -565,38 +565,48 @@ async function runBuild(
           file: fileArg,
           task_id: taskId,
           exit,
+          parse_error: parseError ?? null,
+          raw_result_text: parseError ? raw.resultText : undefined,
           cost_usd: raw.costUsd,
           duration_ms: raw.durationMs,
           num_turns: raw.numTurns,
           session_id: raw.sessionId,
+          stop_reason: raw.stopReason,
         },
         null,
         2
       )}\n`
     );
   } else {
-    process.stdout.write(`builder exit: ${exit.status}\n`);
+    process.stdout.write(`builder exit: ${exit?.status ?? 'PARSE_FAILED'}\n`);
     process.stdout.write(`  cost: $${raw.costUsd.toFixed(4)}\n`);
     process.stdout.write(
       `  duration: ${(raw.durationMs / 1000).toFixed(1)}s\n`
     );
     process.stdout.write(`  turns: ${raw.numTurns}\n`);
     process.stdout.write(`  session: ${raw.sessionId}\n`);
-    if (exit.status === 'success' && exit.commit_sha) {
+    process.stdout.write(`  stop_reason: ${raw.stopReason}\n`);
+    if (parseError) {
+      process.stdout.write(`  parse_error: ${parseError}\n`);
+      process.stdout.write(
+        `  raw_result_text (last 1000 chars):\n---\n${raw.resultText.slice(-1000)}\n---\n`
+      );
+    }
+    if (exit?.status === 'success' && exit.commit_sha) {
       process.stdout.write(`  commit: ${exit.commit_sha}\n`);
     }
-    if (exit.status === 'spec_gap') {
+    if (exit?.status === 'spec_gap') {
       process.stdout.write(
         `  cited: ${exit.cited_section}\n  gap: ${exit.gap_description}\n`
       );
     }
-    if (exit.status === 'verify_fail') {
+    if (exit?.status === 'verify_fail') {
       process.stdout.write(
         `  verify_command: ${exit.verify_command}\n  attempts: ${exit.attempts}\n`
       );
     }
   }
-  process.exit(exit.status === 'success' ? 0 : 2);
+  process.exit(exit?.status === 'success' ? 0 : 2);
 }
 
 async function runReview(
@@ -609,7 +619,7 @@ async function runReview(
   process.stderr.write(
     `harness: dispatching cold-reader subagent for ${taskId}...\n`
   );
-  const { exit, raw } = await dispatchColdReader({
+  const { exit, raw, parseError } = await dispatchColdReader({
     taskId,
     diffRange,
     taskListPath: filePath,
@@ -621,27 +631,41 @@ async function runReview(
           file: fileArg,
           task_id: taskId,
           exit,
+          parse_error: parseError ?? null,
+          raw_result_text: parseError ? raw.resultText : undefined,
           cost_usd: raw.costUsd,
           duration_ms: raw.durationMs,
+          stop_reason: raw.stopReason,
         },
         null,
         2
       )}\n`
     );
   } else {
-    process.stdout.write(`cold-reader verdict: ${exit.verdict}\n`);
+    process.stdout.write(
+      `cold-reader verdict: ${exit?.verdict ?? 'PARSE_FAILED'}\n`
+    );
     process.stdout.write(`  cost: $${raw.costUsd.toFixed(4)}\n`);
-    process.stdout.write(`  findings: ${exit.findings.length}\n`);
-    for (const finding of exit.findings) {
+    process.stdout.write(`  stop_reason: ${raw.stopReason}\n`);
+    if (parseError) {
+      process.stdout.write(`  parse_error: ${parseError}\n`);
       process.stdout.write(
-        `  - ${finding.severity} #${finding.scope_check} (${finding.cited_section}): ${finding.description.slice(0, 100)}\n`
+        `  raw_result_text (last 1000 chars):\n---\n${raw.resultText.slice(-1000)}\n---\n`
       );
     }
-    if (exit.summary) {
-      process.stdout.write(`  summary: ${exit.summary}\n`);
+    if (exit) {
+      process.stdout.write(`  findings: ${exit.findings.length}\n`);
+      for (const finding of exit.findings) {
+        process.stdout.write(
+          `  - ${finding.severity} #${finding.scope_check} (${finding.cited_section}): ${finding.description.slice(0, 100)}\n`
+        );
+      }
+      if (exit.summary) {
+        process.stdout.write(`  summary: ${exit.summary}\n`);
+      }
     }
   }
-  process.exit(exit.verdict === 'approve' ? 0 : 2);
+  process.exit(exit?.verdict === 'approve' ? 0 : 2);
 }
 
 async function runArbitrate(
@@ -656,7 +680,11 @@ async function runArbitrate(
   process.stderr.write(
     `harness: dispatching arbiter subagent for ${specGap.task_id}...\n`
   );
-  const { exit, raw: dispatchRaw } = await dispatchArbiter({
+  const {
+    exit,
+    raw: dispatchRaw,
+    parseError,
+  } = await dispatchArbiter({
     specGap,
     taskListPath: filePath,
   });
@@ -667,23 +695,35 @@ async function runArbitrate(
           file: fileArg,
           spec_gap: specGap,
           exit,
+          parse_error: parseError ?? null,
+          raw_result_text: parseError ? dispatchRaw.resultText : undefined,
           cost_usd: dispatchRaw.costUsd,
           duration_ms: dispatchRaw.durationMs,
+          stop_reason: dispatchRaw.stopReason,
         },
         null,
         2
       )}\n`
     );
   } else {
-    process.stdout.write(`arbiter verdict: ${exit.verdict}\n`);
+    process.stdout.write(
+      `arbiter verdict: ${exit?.verdict ?? 'PARSE_FAILED'}\n`
+    );
     process.stdout.write(`  cost: $${dispatchRaw.costUsd.toFixed(4)}\n`);
-    if (exit.amended_section) {
+    process.stdout.write(`  stop_reason: ${dispatchRaw.stopReason}\n`);
+    if (parseError) {
+      process.stdout.write(`  parse_error: ${parseError}\n`);
+      process.stdout.write(
+        `  raw_result_text (last 1000 chars):\n---\n${dispatchRaw.resultText.slice(-1000)}\n---\n`
+      );
+    }
+    if (exit?.amended_section) {
       process.stdout.write(`  amended: ${exit.amended_section}\n`);
     }
-    if (exit.amendment_text) {
+    if (exit?.amendment_text) {
       process.stdout.write(`  text: ${exit.amendment_text.slice(0, 200)}\n`);
     }
-    if (exit.pushback_message) {
+    if (exit?.pushback_message) {
       process.stdout.write(`  pushback: ${exit.pushback_message}\n`);
     }
   }

--- a/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-1.test.tsx.txt
+++ b/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-1.test.tsx.txt
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render, renderWithUser } from '@test-utils';
+import { StopButton } from './StopButton';
+import { useIncidentStore } from '@store/useIncidentStore';
+import type { IncidentState } from '@store/useIncidentStore';
+
+vi.mock('@store/useIncidentStore');
+
+describe('StopButton', () => {
+  const mockStopIncident = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      activeIncident: null,
+      isLoading: false,
+      error: null,
+      stopIncident: mockStopIncident,
+      startIncident: vi.fn(),
+      hydrateActiveIncident: vi.fn(),
+    } as unknown as IncidentState);
+  });
+
+  it('fires stopIncident when tapped (BR-12, BR-13)', async () => {
+    const { user } = renderWithUser(<StopButton />);
+    await user.click(screen.getByRole('button', { name: 'STOP' }));
+    expect(mockStopIncident).toHaveBeenCalledTimes(1);
+  });
+
+  it('aria-label matches i18n value for incidents.stop (BR-12)', () => {
+    render(<StopButton />);
+    expect(screen.getByRole('button', { name: 'STOP' })).toHaveAttribute(
+      'aria-label',
+      'STOP'
+    );
+  });
+});

--- a/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-1.tsx.txt
+++ b/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-1.tsx.txt
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next';
+import Button from '@mui/material/Button';
+import { useIncidentStore } from '@store/useIncidentStore';
+
+export function StopButton() {
+  const { t } = useTranslation();
+  const { stopIncident } = useIncidentStore();
+  const label = t('incidents.stop');
+
+  return (
+    <Button
+      variant="contained"
+      color="error"
+      aria-label={label}
+      onClick={() => {
+        void stopIncident();
+      }}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-2.test.tsx.txt
+++ b/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-2.test.tsx.txt
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StopButton } from './StopButton';
+import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue: string) => defaultValue,
+  }),
+}));
+
+vi.mock('@store/useIncidentStore');
+
+describe('StopButton', () => {
+  const mockStopIncident = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      stopIncident: mockStopIncident,
+      activeIncident: null,
+      isLoading: false,
+      error: null,
+      startIncident: vi.fn(),
+      hydrateActiveIncident: vi.fn(),
+    } as unknown as IncidentState);
+  });
+
+  it('renders with aria-label matching the i18n value (BR-12)', () => {
+    render(<StopButton />);
+    expect(screen.getByRole('button', { name: 'STOP' })).toBeInTheDocument();
+  });
+
+  it('calls stopIncident store action on tap (BR-13)', async () => {
+    const user = userEvent.setup();
+    render(<StopButton />);
+
+    await user.click(screen.getByRole('button', { name: 'STOP' }));
+
+    expect(mockStopIncident).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-2.tsx.txt
+++ b/scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-2.tsx.txt
@@ -1,0 +1,20 @@
+import { Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useIncidentStore } from '@store/useIncidentStore';
+
+export function StopButton() {
+  const { t } = useTranslation();
+  const { stopIncident } = useIncidentStore();
+  const label = t('incidents.stop', 'STOP');
+
+  return (
+    <Button
+      variant="contained"
+      color="error"
+      aria-label={label}
+      onClick={() => void stopIncident()}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/scripts/harness/evals/builder/cases/regression/round-27-T11-verify-fail-vitest-jest-confusion.input.md
+++ b/scripts/harness/evals/builder/cases/regression/round-27-T11-verify-fail-vitest-jest-confusion.input.md
@@ -1,0 +1,339 @@
+# Builder Agent — System Prompt
+
+You are the **builder** agent in a spec-anchored development harness. Your job
+is to take ONE task from a curated task list and implement it against a TDD
+loop, with strict drift-escalation discipline.
+
+You are NOT a feature designer, a planner, or a code reviewer. Those are
+separate roles. Stay in your lane.
+
+---
+
+## Inputs you receive
+
+Every invocation includes a structured **per-task input** (see `BuilderInput`):
+
+- `task_id` — e.g. `T-07`
+- `description` — task heading after the em-dash
+- `cited_spec_sections` — verbatim text of every spec section/requirement the
+  task cites. **Do not infer beyond what's here.**
+- `cited_design_sections` — verbatim text of every design section the task
+  cites
+- `verify` — the `Verify:` line from the task
+- `notes` — optional `Notes:` body, may include `[DQ-N]` tags
+- `dq_tags` — list of open design questions that touch this task
+- `context_files` — paths to project-convention files you should read
+  (CLAUDE.md, precedent feature files)
+- `allowed_writes` — file paths you are permitted to create or modify
+- `budget` — `{ tokens, wall_clock_minutes, retries }`
+
+You also have full Claude Code tool access scoped to the worktree.
+
+---
+
+## TDD discipline (non-negotiable)
+
+For every task:
+
+1. **Re-read** the cited spec/design sections. Do not trust your memory; do
+   not infer from the task description alone.
+2. **Pre-flight against project state** before any test is written. Two
+   mechanical checks:
+   - **Verify-line vs project pattern.** Does the verify line match the
+     established test pattern for this file class? E.g. if the task says
+     "unit tests against Firestore emulator" but every existing repo test
+     in `src/repositories/*.test.ts` uses `vi.mock('firebase/firestore')`,
+     that's a verify-line/pattern conflict — emit `spec_gap` so the
+     drift-arbiter can `amend_task`. **Do not silently switch patterns
+     either way.**
+   - **Layer-(N-1) surface availability.** If your task composes a
+     repository/service/hook that already exists, read its public surface
+     and confirm the methods/signatures the task assumes are present. If
+     the assumed surface is missing (e.g. you're a service task that needs
+     `repo.createWithId` but the repo only exposes `create`), you have two
+     options: (a) extend layer-(N-1) inside this task's PR as a paired
+     chore commit if the extension is mechanical and one-task-deep, or
+     (b) emit `spec_gap` if the extension touches a surface beyond the
+     immediate need or implies a verify-line amendment on the prior task.
+     **Flag the choice in `notes`** so the cold-reader can see it.
+3. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
+   form. Run them; confirm they fail (RED).
+4. **Implement minimum code** to make the tests pass (GREEN). Avoid
+   gold-plating.
+5. **Refactor.** Keep tests green.
+6. **Run the `Verify:` line literally.** It is the per-task gate.
+7. **Stage exactly the `allowed_writes` files.** No drive-by edits to
+   unrelated files. If you needed to touch something else, that's a
+   `SPEC_GAP` — see drift escalation below.
+8. **Commit** with a message that cites at least one of the spec/design
+   sections you just implemented. Format:
+   `<type>(<scope>): <subject> (<citation>)`
+   Example: `feat(incidents): activation FAB (BR-27, AC-18)`
+   The harness's commit-msg hook validates this; you cannot commit without
+   a citation.
+
+---
+
+## Drift escalation contract
+
+Your most important responsibility after correctness: **never silently expand
+scope**. If you encounter ANY of the following, stop and emit a `SPEC_GAP`
+exit instead of pushing through:
+
+- A cited BR is ambiguous and you'd have to pick a default.
+- A cited design section conflicts with project convention you discovered
+  while reading the precedent files.
+- The Verify line is impossible without writing code outside `allowed_writes`.
+- A required type/function from a different feature module is missing or has
+  a different shape than the design says.
+- You discover a behavior the spec doesn't cover that is genuinely needed
+  for the task to function.
+- **Two rules in this prompt itself conflict on this task.** Most commonly:
+  the TDD rule (#3 — "Write tests first; tests must assert the cited ACs")
+  presumes the task cites ACs and the verify line permits running tests
+  against the produced code. If the task cites no ACs AND the verify line is
+  structural (e.g. _"`tsc -b` passes with the new file imported nowhere"_),
+  the TDD rule has no clear application — there are no ACs to assert and
+  satisfying TDD by writing a test would import the file and break the verify
+  gate. **Even if you can navigate the conflict reasonably**, do not. Escalate.
+  The drift-arbiter will either amend the task/spec to remove the conflict
+  (e.g. revise the verify line to permit a type-only test, or add an explicit
+  task-level note that TDD does not apply) or apply a one-time pushback
+  authorizing your interpretation. Either way, the decision gets logged
+  rather than living silently in your reasoning.
+
+In every case, the right move is the same: **stop, surface the gap, exit.**
+The drift-arbiter agent will resolve it (amend the spec, amend the design,
+or push back to clarify) and you'll be re-dispatched with refreshed context.
+
+You MUST NOT:
+
+- Silently invent a default value.
+- Make implementation choices the design phase didn't make.
+- Touch files outside `allowed_writes` "just to make it work".
+- Skip a test because the cited AC is hard to verify.
+- **Skip a test because the verify line forbids importing the produced code.**
+  That's a rule conflict — escalate per the trigger above.
+- Lie about Verify passing — if you cannot run it cleanly, that's a
+  `verify_fail` exit, not a `success`.
+- **Invoke any infrastructure-deploy command as part of a verify gate.**
+  This includes (non-exhaustive): `firebase deploy`, `vercel deploy`,
+  `gcloud … deploy`, `kubectl apply`, `terraform apply`, any `deploy:*`
+  npm/pnpm script that targets a shared environment, any production
+  database migration runner. Verify gates must run against local emulators
+  (`firebase emulators:start --only firestore`), local servers, or the
+  in-process test runner. Deploys are post-merge human steps; if a task's
+  verify line names a deploy command, emit `spec_gap` and let the
+  drift-arbiter `amend_task` the verify line to an emulator/local
+  equivalent. Methodology basis: round-24 hit a 3-instance threshold
+  (T-01, T-04, T-03) on this exact pattern; this rule generalizes the
+  pattern.
+
+---
+
+## Output contract
+
+Exit with exactly one of these structured payloads (YAML or JSON, your
+choice — controller parses both):
+
+### success
+
+```yaml
+status: success
+commit_sha: <40-char SHA>
+verify_run:
+  typecheck: pass
+  lint: pass
+  test: pass
+  build: pass # only if the task touches build-relevant files
+files_touched:
+  - <path>
+notes: |
+  <free-form, optional — anything the cold-reader should know>
+```
+
+### spec_gap
+
+```yaml
+status: spec_gap
+cited_section: BR-N | §DN | etc.
+gap_description: |
+  <one paragraph describing what was unclear or missing>
+suggested_amendment: |
+  <one paragraph proposing the smallest possible spec/design change>
+files_inspected:
+  - <relevant precedent files you read while discovering the gap>
+```
+
+### verify_fail
+
+```yaml
+status: verify_fail
+verify_command: <the exact command that failed>
+output_tail: |
+  <last ~30 lines of failed output>
+attempts: <how many times you tried this iteration>
+```
+
+### budget_exceeded
+
+```yaml
+status: budget_exceeded
+spent:
+  tokens: <approx>
+  wall_clock_minutes: <approx>
+last_action: |
+  <one sentence on what you were doing when you hit the cap>
+```
+
+---
+
+## Things you do NOT do
+
+- You do not pick the next task. The controller does that.
+- You do not review your own work for spec compliance. The cold-reader does
+  that, in a separate session, with no memory of yours.
+- You do not amend the spec or design. The drift-arbiter does that, on
+  receipt of your `spec_gap` exit.
+- You do not push to remote. The controller does that after the cold-reader
+  approves.
+- You do not navigate slice boundaries. The controller halts at boundaries
+  and prompts the human.
+
+---
+
+## Style
+
+Match `CLAUDE.md` and the existing project conventions discovered in
+`context_files`. Project-specific rules ALWAYS override your defaults.
+When in doubt, mirror the precedent files literally — that's what the design
+phase chose them as the precedent for.
+
+---
+
+# Task: T-11 — StopButton component
+
+**Slice:** 1 (Minimum viable activation (one-tap → timer → STOP → saved))
+
+## Cited spec/design context
+
+### BR-12 (spec)
+
+- **BR-12** — A STOP action MUST be available throughout the active incident.
+
+### BR-13 (spec)
+
+- **BR-13** — On STOP, the timer MUST freeze at the current elapsed time and the incident MUST persist with `endedAt = now`. (Pet is always set per BR-28; no pet picker is invoked at STOP.)
+
+### §D2 (design)
+
+## §D2 Architecture
+
+Following the medications precedent (`src/features/medications/*`, `src/repositories/PetMedicationRepository.ts`, `src/services/petMedicationService.ts`, `src/store/usePetMedicationStore.ts`).
+
+### File map
+
+```
+src/features/incidents/
+  pages/
+    ActiveIncidentPage.tsx              # /incidents/active route — loads activeIncident from store, renders <IncidentCaptureSurface>
+    ActiveIncidentPage.test.tsx
+    SavedIncidentPage.tsx               # /pets/:petId/incidents/:id route — loads incident by id, renders <IncidentCaptureSurface>
+    SavedIncidentPage.test.tsx
+  components/
+    IncidentCaptureSurface.tsx          # SHARED surface used by both pages (BR-14, BR-25 — same surface live, post-stop, re-opened)
+    IncidentCaptureSurface.test.tsx
+    IncidentTimer.tsx                   # monospace hero, ticks every ~250ms (see §D8)
+    IncidentTimer.test.tsx
+    SeverityChips.tsx                   # 3-up grid (BR-6)
+    SeverityChips.test.tsx
+    ObservationChips.tsx                # type-aware grid (BR-7, BR-19, BR-32)
+    ObservationChips.test.tsx
+    IncidentJournal.tsx                 # append-only textarea (BR-8, BR-9, BR-30)
+    IncidentJournal.test.tsx
+    VetCallCard.tsx                     # tel: link (BR-10, BR-11)
+    VetCallCard.test.tsx
+    ActivationPetPicker.tsx             # bottom-Drawer picker shown when global FAB is tapped on a non-pet-scoped surface for multi-pet users (BR-28 third rule, DQ-7 resolution)
+    ActivationPetPicker.test.tsx
+    StopButton.tsx                      # (BR-12, BR-13)
+    StopButton.test.tsx
+    DeleteIncidentAction.tsx            # soft-delete trigger (BR-33)
+    DeleteIncidentAction.test.tsx
+    ResumeIncidentBanner.tsx            # global persistent banner offering to navigate to active incident (DQ-2 resolution)
+    ResumeIncidentBanner.test.tsx
+    IncidentHistoryList.tsx             # per-pet list (BR-23, BR-24, BR-25)
+    IncidentHistoryList.test.tsx
+  hooks/
+    useActiveIncident.ts                # selector + actions (start, stop, mutate, delete)
+    useActiveIncident.test.ts
+    useIncidentTimer.ts                 # rAF-driven elapsed seconds
+    useIncidentTimer.test.ts
+  types.ts                              # Incident, IncidentType, Severity, ChipId
+  chipCatalog.ts                        # static type→chips map (resolves OQ-3)
+
+src/repositories/
+  IncidentRepository.ts                 # CRUD against Firestore (NFR-8, BR-15)
+
+src/services/
+  incidentService.ts                    # business logic, composes repository
+                                        # — exposes getRecentTypesForPet(petId, limit=10): IncidentTypeId[]
+                                        #   for BR-21's MRU-per-pet sort. Implementation: query per-pet history
+                                        #   (composite index already covers it), map to types, dedupe preserving order.
+
+src/store/
+  useIncidentStore.ts                   # Zustand: activeIncident + per-pet history maps
+
+src/components/common/
+  EmergencyActivationFab.tsx            # global FAB, mounted in App.tsx (BR-27, AC-18)
+  EmergencyActivationFab.test.tsx
+```
+
+### Routes
+
+Add to `src/AppRoutes.tsx`:
+
+- `/incidents/active` → `ActiveIncidentPage` (auth-guarded; redirects to `/pets` if no active incident)
+- `/pets/:petId/incidents/:incidentId` → `SavedIncidentPage` (auth-guarded; pet-scoped per BR-23/25)
+
+Both gated behind a new `incidentsEnabled` feature flag, matching the existing pattern (`enableVets`, `enablePetList`, etc. in `src/AppRoutes.tsx:31-39`).
+
+### Global activation FAB (BR-27, AC-18)
+
+`EmergencyActivationFab` mounts in `src/App.tsx` outside the route tree so it survives navigation. Hidden when:
+
+- user is unauthenticated
+- the active route is `/incidents/active` (DQ-3 resolution: hidden — no-op there; the active surface itself owns navigation)
+- `incidentsEnabled` flag is off
+- the user has zero pets (per BR-27's round-5 zero-pet exception, added in spec to make this design behavior consistent with the requirement)
+
+Built with MUI `<Fab>`, positioned bottom-right with `position: fixed`. Tap target ≥56×56 (BR-27, NFR-3).
+
+**Tap behavior** (per BR-26 short-circuit and BR-28's three rules):
+
+| Pre-condition              | Surface                       | Pet count | Behavior                                                                                                                   |
+| -------------------------- | ----------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Active incident exists** | any                           | any       | Navigate to `/incidents/active` (resume — BR-26, AC-11). All other rules below skip.                                       |
+| No active incident         | Pet-scoped (e.g. `/pets/:id`) | any       | Activate immediately with that pet (1 tap, AC-20).                                                                         |
+| No active incident         | Non-pet-scoped                | exactly 1 | Activate immediately with the only pet (1 tap, AC-20).                                                                     |
+| No active incident         | Non-pet-scoped                | 2+        | Open `ActivationPetPicker` as an MUI bottom Drawer (DQ-7 resolution); the pet tap IS the activation (2 taps total, AC-19). |
+
+---
+
+## Verify (the per-task gate)
+
+Component test: tap fires the store action; `aria-label` matches the i18n value.
+
+## Project context files
+
+Read these for project conventions:
+- `CLAUDE.md`
+
+## Files you may create or modify
+
+_None pre-specified. Derive from the cited design §D2 file map and stage only those._
+
+## Budget
+
+- tokens: ~100,000
+- wall clock: 15 min
+- retries on verify_fail: 2

--- a/scripts/harness/evals/builder/cases/regression/round-27-T11-verify-fail-vitest-jest-confusion.json
+++ b/scripts/harness/evals/builder/cases/regression/round-27-T11-verify-fail-vitest-jest-confusion.json
@@ -1,0 +1,31 @@
+{
+  "case_id": "regression-round-27-T11-verify-fail-vitest-jest-confusion",
+  "task_id": "T-11",
+  "source": "Round-27 first live e2e dispatch via `pnpm tsx scripts/harness/cli.ts build T-11`. The subagent produced correct StopButton code + tests (independently verified to pass) but emitted `verify_fail` after 4 attempts because it constructed the verify command using Jest CLI syntax (`pnpm run test:unit -- --testPathPattern=StopButton`) rather than Vitest's positional arg pattern. The task's verify line says 'Component test: tap fires the store action; aria-label matches the i18n value' — it does NOT specify the exact command, leaving the subagent to invent one. Two methodology findings: (a) builder needs to consult package.json scripts / CLAUDE.md for the project's test runner; (b) verify-line specificity matters when the project uses non-default tools.",
+  "input": {
+    "rendered_builder_input_path": "scripts/harness/evals/builder/cases/regression/round-27-T11-verify-fail-vitest-jest-confusion.input.md"
+  },
+  "expected": {
+    "status": "verify_fail",
+    "verify_command_pattern": "(?i)(testPathPattern|--testPathPattern|jest|test:unit)",
+    "attempts_min": 1
+  },
+  "actual_baseline": {
+    "status": "verify_fail",
+    "verify_command": "pnpm run test:unit -- --testPathPattern=StopButton",
+    "attempts": 4,
+    "wall_clock_seconds": 212,
+    "tokens_consumed": null,
+    "cost_usd": 0.7135,
+    "tool_uses": null,
+    "session_id": "71c67702-fb6f-46a2-9cc9-93c1d062daa4",
+    "stop_reason": "end_turn",
+    "num_turns": 25,
+    "files_touched_evidence": [
+      "scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-2.tsx",
+      "scripts/harness/evals/builder/cases/regression/round-27-T11-evidence/StopButton-attempt-2.test.tsx"
+    ],
+    "notes": "Subagent's code is correct — independently verified by `pnpm exec vitest run src/features/incidents/components/StopButton.test.tsx` produces 2/2 passing tests. The harness's verify_fail verdict reflects the subagent's wrong command construction, not bad code. This is the FIRST verify_fail exit emitted in the wild (rounds 17-26 produced only success/spec_gap)."
+  },
+  "notes": "Methodology carry-overs (round 27): (1) update builder.md to instruct subagents to consult package.json `scripts` block before constructing verify commands, OR (2) require task verify lines to specify the exact runner command for non-default test tools. Both candidate fixes worth A/B once the next live dispatch happens. Companion file: `round-27-T11-evidence/` directory holds both the attempt-1 (parse_error before round-27 dispatcher fix) and attempt-2 (verify_fail with proper exit) StopButton implementations. Both produce correct code; both fail the harness gate for different reasons."
+}

--- a/scripts/harness/lib/dispatch/arbiter-dispatch.ts
+++ b/scripts/harness/lib/dispatch/arbiter-dispatch.ts
@@ -43,8 +43,9 @@ export interface ArbiterDispatchOptions {
 }
 
 export interface ArbiterDispatchResult {
-  exit: ArbiterExit;
+  exit: ArbiterExit | null;
   raw: DispatchResult;
+  parseError?: string;
 }
 
 const DEFAULT_TASK_LIST = 'docs/specs/incident-capture/03-tasks.md';
@@ -84,8 +85,13 @@ export async function dispatchArbiter(
     spawnImpl: opts.spawnImpl,
   });
 
-  const exit = parseArbiterExit(raw.resultText);
-  return { exit, raw };
+  try {
+    const exit = parseArbiterExit(raw.resultText);
+    return { exit, raw };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { exit: null, raw, parseError: reason };
+  }
 }
 
 export function parseArbiterExit(text: string): ArbiterExit {

--- a/scripts/harness/lib/dispatch/builder-dispatch.ts
+++ b/scripts/harness/lib/dispatch/builder-dispatch.ts
@@ -81,8 +81,12 @@ export interface BuilderDispatchOptions {
 }
 
 export interface BuilderDispatchResult {
-  exit: BuilderExit;
+  /** The parsed structured exit, OR null when the subagent did not emit one. */
+  exit: BuilderExit | null;
+  /** Raw envelope from claude -p (cost, duration, turns, session, full result text). */
   raw: DispatchResult;
+  /** When `exit` is null, why the parse failed. */
+  parseError?: string;
 }
 
 const DEFAULT_TASK_LIST = 'docs/specs/incident-capture/03-tasks.md';
@@ -139,8 +143,13 @@ export async function dispatchBuilder(
     spawnImpl: opts.spawnImpl,
   });
 
-  const exit = parseBuilderExit(raw.resultText);
-  return { exit, raw };
+  try {
+    const exit = parseBuilderExit(raw.resultText);
+    return { exit, raw };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { exit: null, raw, parseError: reason };
+  }
 }
 
 export function parseBuilderExit(text: string): BuilderExit {

--- a/scripts/harness/lib/dispatch/cold-reader-dispatch.ts
+++ b/scripts/harness/lib/dispatch/cold-reader-dispatch.ts
@@ -48,8 +48,9 @@ export interface ColdReaderDispatchOptions {
 }
 
 export interface ColdReaderDispatchResult {
-  exit: ColdReaderExit;
+  exit: ColdReaderExit | null;
   raw: DispatchResult;
+  parseError?: string;
 }
 
 const DEFAULT_TASK_LIST = 'docs/specs/incident-capture/03-tasks.md';
@@ -95,8 +96,13 @@ export async function dispatchColdReader(
     spawnImpl: opts.spawnImpl,
   });
 
-  const exit = parseColdReaderExit(raw.resultText);
-  return { exit, raw };
+  try {
+    const exit = parseColdReaderExit(raw.resultText);
+    return { exit, raw };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { exit: null, raw, parseError: reason };
+  }
 }
 
 function readGitDiff(range: string, cwd?: string): string {


### PR DESCRIPTION
## Summary

Round 27's first live `harness build T-11` dispatch produced two findings worth shipping: (a) the dispatcher should never throw on a parse failure — the cost/duration/turns/session/stop_reason metadata is too valuable to discard; (b) the FIRST live `verify_fail` exit in the wild deserves a regression case.

## What happened on the live dispatch

Cost: $0.7135. Duration: 212s. Turns: 25. Stop: end_turn. Verify attempts: 4.

The subagent built T-11 (StopButton) correctly — independently verified that the produced code + tests pass when run via `pnpm exec vitest run <path>`. But it constructed the verify command as `pnpm run test:unit -- --testPathPattern=StopButton`, which is **Jest CLI syntax**. Vitest doesn't recognize `--testPathPattern`. After 4 retries the subagent emitted `verify_fail` and stopped.

Two methodology findings (logged in the case JSON's notes for follow-up):
1. **Builder should consult `package.json` scripts before constructing verify commands.** Currently the prompt instructs "Run the Verify line literally" — but when the verify line is descriptive ("Component test: tap fires the store action") rather than commanded, the subagent invents one.
2. **Task verify lines that don't specify the exact command leave the subagent to invent.** For non-default tools (Vitest), this is risky.

Both candidate fixes for next-round prompt iteration. Not in this PR.

## Changes

### Dispatcher resilience (no more throws on parse failure)

All three role dispatchers (`builder-dispatch.ts`, `cold-reader-dispatch.ts`, `arbiter-dispatch.ts`) now return `{ exit: <Type> | null, raw, parseError? }` instead of throwing when the structured exit can't be parsed. The CLI prints `parse_error` + the last 1000 chars of the raw result text + the dispatch metadata so we can diagnose what came back.

### First live `verify_fail` regression case

`scripts/harness/evals/builder/cases/regression/round-27-T11-verify-fail-vitest-jest-confusion.{json,input.md}`

Pinned input.md (rendered via `harness prepare T-11`), structured expected payload (status: verify_fail, verify_command_pattern matching the Jest-isms), and the actual_baseline filled in with real cost/duration/session-id from the live dispatch. Companion `round-27-T11-evidence/` directory holds both attempt-1 (parse_error before this PR's fix) and attempt-2 (verify_fail with proper exit) StopButton files as evidence (`.tsx.txt` extension to keep vitest from globbing them).

### Other

- `.gitignore` adds `.harness/` for runtime state per architecture plan §1 (state.json, worktrees/, etc.). Empty today; reserved.

## Verify

- `pnpm exec tsc -b`: clean
- `pnpm exec vitest run scripts/harness/lib/dispatch/`: 34/34 PASS
- `pnpm tsx scripts/harness/evals/cli-snapshots/run.ts`: 3/3 PASS
- `pnpm tsx scripts/harness/evals/builder/run.ts`: 9 cases load + validate (was 8)

## Carry-overs

- Methodology fix: builder.md verify-command guidance (next round)
- Re-dispatch T-11 once the methodology fix lands to validate it cleanly succeeds + commits + emits a parseable success exit
- Eval grid bumped: builder regression 8 → 9 (incl. first verify_fail in the wild)

## Test plan

- [ ] CI green
- [ ] Reviewer reads the dispatcher null-exit handling + the new case JSON