### PR TITLE
chore(harness): add pnpm preflight + wire into pre-push for local CI parity

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,1 @@
-pnpm run build
-pnpm run test:coverage
+pnpm preflight

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ Package manager is **pnpm** (pinned via `packageManager` field). Use `pnpm`, not
 - Run a single test: `pnpm exec vitest run path/to/file.test.tsx` (add `-t "name"` to filter by test name)
 - Deploy: `pnpm run deploy:dev` / `pnpm run deploy:staging` (sets `firebase use` then deploys hosting + firestore.rules + storage)
 
+### Local CI parity
+
+`pnpm run preflight` runs the full set of checks CI runs in `ci-pr.yml`'s main job: `lint && knip && build && test:coverage`. Wired into `.husky/pre-push` so every push runs them locally first. Mirror is intentional — it eliminates the local==CI drift that historically bit us when `knip` flagged in-progress slice exports as dead code (rounds 26+).
+
+The one CI check NOT in `preflight` is `pnpm run test:rules` (Firestore + Storage rules under emulator). Emulator setup is heavy (~30s) so it's intentionally local-optional. Run it manually when touching `firestore.rules` / `storage.rules`: `pnpm run test:rules` (requires the Firebase emulator suite installed).
+
 Local Firebase Auth emulator runs on `localhost:9099`; the app auto-connects when running on `localhost` (see `src/firebase.ts`). Do not sign in with real accounts against the emulator.
 
 ## Architecture

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "harness": "tsx scripts/harness/cli.ts",
     "knip": "knip",
     "knip:fix": "knip --fix --allow-remove-files",
+    "preflight": "pnpm run lint && pnpm knip --no-progress && pnpm run build && pnpm run test:coverage",
     "start:firebase": "firebase emulators:start --only auth,firestore,storage",
     "prepare": "husky",
     "deploy:dev": "firebase use dev && firebase deploy --only hosting,firestore:rules,storage",


### PR DESCRIPTION
## Summary

Local pre-push previously ran `build` + `test:coverage` only. CI runs those PLUS `lint` (whole project) + `knip` (dead-code). The gap bit us round 28 — PR #170 failed CI on knip after passing all local checks, requiring a follow-up commit to fix.

## What changed

1. **`package.json`** — new `preflight` script:
   ```json
   "preflight": "pnpm run lint && pnpm knip --no-progress && pnpm run build && pnpm run test:coverage"
   ```
   Mirrors what `ci-pr.yml`'s main job runs.

2. **`.husky/pre-push`** — body replaced with `pnpm preflight`. Net delta on push time: +lint (~5s) +knip (~1s). Total goes from ~30s to ~35s.

3. **`CLAUDE.md`** — new "Local CI parity" subsection under Commands. Documents `pnpm preflight` + notes that `test:rules` is the one CI check NOT in preflight (emulator is heavy; run separately when touching `firestore.rules` / `storage.rules`).

## Verification

- `pnpm preflight` exits 0 on this branch.
- Smoke-tested by introducing a deliberate unused export (`src/__preflight-canary.ts`); knip exited 1 with `Unused files (1) src/__preflight-canary.ts`. Removed.
- **This PR's push was the first to run the new pre-push hook.** It passed.
- The same canary would have caught the round-28 `IncidentService` knip failure locally.

## Why ship now (vs. defer until slice 1 ships)

The next 5+ live dispatches (T-11 re-dispatch, then T-12..T-15) will produce commits with new exports. Each is a candidate for the same knip-style surprise. Cost of catching locally: 5s per push. Cost of catching at CI: minutes per round-trip + opens a new commit cycle. Preflight pays for itself within 1-2 dispatches.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms `pnpm preflight` runs locally and matches CI's main job