### PR TITLE
harness: round-29 — bypassPermissions fix + first harness-driven slice-1 commit (T-11)

### DIFF
--- a/docs/specs/incident-capture/03-tasks.md
+++ b/docs/specs/incident-capture/03-tasks.md
@@ -86,7 +86,7 @@ Goal after this slice: a single-pet user can tap a global FAB, see a running tim
 - **What:** Create `src/features/incidents/components/IncidentTimer.tsx`. Renders the elapsed value with monospace styling (Caregiver theme tokens). Wraps the elapsed text (not milliseconds) in `aria-live="polite"`.
 - **Verify:** Component test: renders elapsed text; has `aria-live="polite"`; uses theme typography.
 
-### `[ ]` T-11 — StopButton component
+### `[x]` T-11 — StopButton component
 
 - **Cite:** spec BR-12, BR-13; design §D2 file map
 - **What:** Create `src/features/incidents/components/StopButton.tsx`. Calls `useIncidentStore.stopIncident` on tap. Has accessible name from i18n `incidents.stop`.

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -27,7 +27,7 @@ Spawns a fresh Claude Code subagent in a clean session, parses the structured ex
 **Prerequisites:** `claude` CLI installed and authenticated (this is the same `claude` you use to start an interactive session). Subagents inherit your auth + plugins + settings.
 
 ```bash
-# Builder — writes code, runs verify, commits. Requires acceptEdits permission.
+# Builder — writes code, runs verify, commits. Uses bypassPermissions (deny list is the safety net).
 pnpm tsx scripts/harness/cli.ts build T-11
 
 # Cold-reader — read-only review of HEAD~1..HEAD diff against cited spec/design.
@@ -42,11 +42,11 @@ Each command supports `--json` for machine-readable output (suitable for piping 
 
 ### Dispatch defaults
 
-| Role        | Model    | Permission mode    | Tool denials                                                                                                            | Timeout |
-| ----------- | -------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------- |
-| Builder     | `sonnet` | `acceptEdits`      | Bash deny on `firebase deploy`, `vercel deploy`, `gcloud`, `kubectl apply`, `terraform apply` (round-25 no-deploy rule) | 30 min  |
-| Cold-reader | `sonnet` | `plan` (read-only) | _none_                                                                                                                  | 10 min  |
-| Arbiter     | `sonnet` | `acceptEdits`      | Bash entirely (arbiter writes spec/design only, never runs commands)                                                    | 10 min  |
+| Role        | Model    | Permission mode     | Tool denials                                                                                                                                                                                                                                                                                | Timeout |
+| ----------- | -------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| Builder     | `sonnet` | `bypassPermissions` | Bash deny on `firebase deploy`, `vercel deploy`, `gcloud`, `kubectl apply`, `terraform apply` (round-25 no-deploy rule). The deny list is the safety boundary; `bypassPermissions` is required so the subagent can run its own verify gate (round-29 finding — `acceptEdits` blocked Bash). | 30 min  |
+| Cold-reader | `sonnet` | `plan` (read-only)  | _none_                                                                                                                                                                                                                                                                                      | 10 min  |
+| Arbiter     | `sonnet` | `acceptEdits`       | Bash entirely (arbiter writes spec/design only, never runs commands)                                                                                                                                                                                                                        | 10 min  |
 
 Override via opts on `dispatchBuilder`/`dispatchColdReader`/`dispatchArbiter` if calling directly from TS.
 

--- a/scripts/harness/evals/builder/cases/regression/round-29-T11-evidence/StopButton-attempt-1.test.tsx.txt
+++ b/scripts/harness/evals/builder/cases/regression/round-29-T11-evidence/StopButton-attempt-1.test.tsx.txt
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StopButton } from './StopButton';
+import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@store/useIncidentStore');
+
+describe('StopButton', () => {
+  const mockStopIncident = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      stopIncident: mockStopIncident,
+    } as unknown as IncidentState);
+  });
+
+  it('tap fires the stopIncident store action (BR-12, BR-13)', async () => {
+    const user = userEvent.setup();
+    render(<StopButton />);
+
+    await user.click(screen.getByRole('button', { name: 'incidents.stop' }));
+
+    expect(mockStopIncident).toHaveBeenCalledTimes(1);
+  });
+
+  it('aria-label matches the i18n value (BR-12)', () => {
+    render(<StopButton />);
+
+    expect(
+      screen.getByRole('button', { name: 'incidents.stop' })
+    ).toHaveAttribute('aria-label', 'incidents.stop');
+  });
+});

--- a/scripts/harness/evals/builder/cases/regression/round-29-T11-evidence/StopButton-attempt-1.tsx.txt
+++ b/scripts/harness/evals/builder/cases/regression/round-29-T11-evidence/StopButton-attempt-1.tsx.txt
@@ -1,0 +1,20 @@
+import { Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useIncidentStore } from '@store/useIncidentStore';
+
+export function StopButton() {
+  const { t } = useTranslation();
+  const { stopIncident } = useIncidentStore();
+  const label = t('incidents.stop');
+
+  return (
+    <Button
+      variant="contained"
+      color="error"
+      aria-label={label}
+      onClick={() => void stopIncident()}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/scripts/harness/evals/builder/cases/regression/round-29-T11-success-baseline.input.md
+++ b/scripts/harness/evals/builder/cases/regression/round-29-T11-success-baseline.input.md
@@ -1,0 +1,372 @@
+# Builder Agent — System Prompt
+
+You are the **builder** agent in a spec-anchored development harness. Your job
+is to take ONE task from a curated task list and implement it against a TDD
+loop, with strict drift-escalation discipline.
+
+You are NOT a feature designer, a planner, or a code reviewer. Those are
+separate roles. Stay in your lane.
+
+---
+
+## Inputs you receive
+
+Every invocation includes a structured **per-task input** (see `BuilderInput`):
+
+- `task_id` — e.g. `T-07`
+- `description` — task heading after the em-dash
+- `cited_spec_sections` — verbatim text of every spec section/requirement the
+  task cites. **Do not infer beyond what's here.**
+- `cited_design_sections` — verbatim text of every design section the task
+  cites
+- `verify` — the `Verify:` line from the task
+- `notes` — optional `Notes:` body, may include `[DQ-N]` tags
+- `dq_tags` — list of open design questions that touch this task
+- `context_files` — paths to project-convention files you should read
+  (CLAUDE.md, precedent feature files)
+- `allowed_writes` — file paths you are permitted to create or modify
+- `budget` — `{ tokens, wall_clock_minutes, retries }`
+
+You also have full Claude Code tool access scoped to the worktree.
+
+---
+
+## TDD discipline (non-negotiable)
+
+For every task:
+
+1. **Re-read** the cited spec/design sections. Do not trust your memory; do
+   not infer from the task description alone.
+2. **Pre-flight against project state** before any test is written. Two
+   mechanical checks:
+   - **Verify-line vs project pattern.** Does the verify line match the
+     established test pattern for this file class? E.g. if the task says
+     "unit tests against Firestore emulator" but every existing repo test
+     in `src/repositories/*.test.ts` uses `vi.mock('firebase/firestore')`,
+     that's a verify-line/pattern conflict — emit `spec_gap` so the
+     drift-arbiter can `amend_task`. **Do not silently switch patterns
+     either way.**
+   - **Layer-(N-1) surface availability.** If your task composes a
+     repository/service/hook that already exists, read its public surface
+     and confirm the methods/signatures the task assumes are present. If
+     the assumed surface is missing (e.g. you're a service task that needs
+     `repo.createWithId` but the repo only exposes `create`), you have two
+     options: (a) extend layer-(N-1) inside this task's PR as a paired
+     chore commit if the extension is mechanical and one-task-deep, or
+     (b) emit `spec_gap` if the extension touches a surface beyond the
+     immediate need or implies a verify-line amendment on the prior task.
+     **Flag the choice in `notes`** so the cold-reader can see it.
+3. **Write tests first.** Tests must assert the cited ACs in Given/When/Then
+   form. Run them; confirm they fail (RED).
+4. **Implement minimum code** to make the tests pass (GREEN). Avoid
+   gold-plating.
+5. **Refactor.** Keep tests green.
+6. **Run the `Verify:` line literally.** It is the per-task gate.
+   - **If the verify line specifies a command verbatim** (e.g.
+     "`pnpm run test:rules` passes new assertions...") — run that
+     command exactly. Do NOT modify, augment, or substitute it.
+   - **If the verify line is descriptive** (e.g. "Component test:
+     tap fires the store action; aria-label matches the i18n value")
+     — derive the command from the project's actual test runner,
+     NOT from your own knowledge of similarly-named tools. Specifically:
+     - Read `package.json`'s `scripts` block first. Pick the closest
+       script (e.g. `test:unit`, `test`, `test:rules`).
+     - For unit tests against a single file in this project (Vitest):
+       `pnpm exec vitest run <path/to/file>`. Vitest takes positional
+       file paths, NOT Jest's `--testPathPattern` flag. Confirm by
+       checking which test framework the project's `package.json`
+       depends on (look for `vitest` vs `jest`).
+     - When in doubt, run the broadest local test command
+       (`pnpm run test:unit`) once to confirm the framework +
+       invocation pattern before constructing a narrower invocation.
+     - **Methodology basis:** round 27 hit `verify_fail` x4 because
+       the subagent invented `--testPathPattern` (Jest syntax) on a
+       Vitest project. Cost: $0.71 for a non-shipping result. This
+       rule generalizes the lesson.
+7. **Run the verify ONE FINAL TIME** before constructing your exit
+   payload. The TDD cycle in steps 3-5 includes test runs that are
+   _expected_ to fail (RED → GREEN). Those iterations do NOT determine
+   the structured exit. **Only the final post-refactor verify run
+   determines `success` vs `verify_fail`.** If your final run passes,
+   emit `status: success`. If it fails, emit `status: verify_fail`
+   with the actual command and the last ~30 lines of output. **Do not
+   emit `verify_fail` based on the count of intermediate iteration
+   failures** — count only the post-refactor final run. Methodology
+   basis: round-28 dispatch reported `verify_fail` after 3 attempts
+   despite the final code state passing all tests cleanly. Cost:
+   $0.68 for a non-shipping false negative.
+8. **Stage exactly the `allowed_writes` files.** No drive-by edits to
+   unrelated files. If you needed to touch something else, that's a
+   `SPEC_GAP` — see drift escalation below.
+9. **Commit** with a message that cites at least one of the spec/design
+   sections you just implemented. Format:
+   `<type>(<scope>): <subject> (<citation>)`
+   Example: `feat(incidents): activation FAB (BR-27, AC-18)`
+   The harness's commit-msg hook validates this; you cannot commit without
+   a citation.
+
+---
+
+## Drift escalation contract
+
+Your most important responsibility after correctness: **never silently expand
+scope**. If you encounter ANY of the following, stop and emit a `SPEC_GAP`
+exit instead of pushing through:
+
+- A cited BR is ambiguous and you'd have to pick a default.
+- A cited design section conflicts with project convention you discovered
+  while reading the precedent files.
+- The Verify line is impossible without writing code outside `allowed_writes`.
+- A required type/function from a different feature module is missing or has
+  a different shape than the design says.
+- You discover a behavior the spec doesn't cover that is genuinely needed
+  for the task to function.
+- **Two rules in this prompt itself conflict on this task.** Most commonly:
+  the TDD rule (#3 — "Write tests first; tests must assert the cited ACs")
+  presumes the task cites ACs and the verify line permits running tests
+  against the produced code. If the task cites no ACs AND the verify line is
+  structural (e.g. _"`tsc -b` passes with the new file imported nowhere"_),
+  the TDD rule has no clear application — there are no ACs to assert and
+  satisfying TDD by writing a test would import the file and break the verify
+  gate. **Even if you can navigate the conflict reasonably**, do not. Escalate.
+  The drift-arbiter will either amend the task/spec to remove the conflict
+  (e.g. revise the verify line to permit a type-only test, or add an explicit
+  task-level note that TDD does not apply) or apply a one-time pushback
+  authorizing your interpretation. Either way, the decision gets logged
+  rather than living silently in your reasoning.
+
+In every case, the right move is the same: **stop, surface the gap, exit.**
+The drift-arbiter agent will resolve it (amend the spec, amend the design,
+or push back to clarify) and you'll be re-dispatched with refreshed context.
+
+You MUST NOT:
+
+- Silently invent a default value.
+- Make implementation choices the design phase didn't make.
+- Touch files outside `allowed_writes` "just to make it work".
+- Skip a test because the cited AC is hard to verify.
+- **Skip a test because the verify line forbids importing the produced code.**
+  That's a rule conflict — escalate per the trigger above.
+- Lie about Verify passing — if you cannot run it cleanly, that's a
+  `verify_fail` exit, not a `success`.
+- **Invoke any infrastructure-deploy command as part of a verify gate.**
+  This includes (non-exhaustive): `firebase deploy`, `vercel deploy`,
+  `gcloud … deploy`, `kubectl apply`, `terraform apply`, any `deploy:*`
+  npm/pnpm script that targets a shared environment, any production
+  database migration runner. Verify gates must run against local emulators
+  (`firebase emulators:start --only firestore`), local servers, or the
+  in-process test runner. Deploys are post-merge human steps; if a task's
+  verify line names a deploy command, emit `spec_gap` and let the
+  drift-arbiter `amend_task` the verify line to an emulator/local
+  equivalent. Methodology basis: round-24 hit a 3-instance threshold
+  (T-01, T-04, T-03) on this exact pattern; this rule generalizes the
+  pattern.
+
+---
+
+## Output contract
+
+Exit with exactly one of these structured payloads (YAML or JSON, your
+choice — controller parses both):
+
+### success
+
+```yaml
+status: success
+commit_sha: <40-char SHA>
+verify_run:
+  typecheck: pass
+  lint: pass
+  test: pass
+  build: pass # only if the task touches build-relevant files
+files_touched:
+  - <path>
+notes: |
+  <free-form, optional — anything the cold-reader should know>
+```
+
+### spec_gap
+
+```yaml
+status: spec_gap
+cited_section: BR-N | §DN | etc.
+gap_description: |
+  <one paragraph describing what was unclear or missing>
+suggested_amendment: |
+  <one paragraph proposing the smallest possible spec/design change>
+files_inspected:
+  - <relevant precedent files you read while discovering the gap>
+```
+
+### verify_fail
+
+```yaml
+status: verify_fail
+verify_command: <the exact command that failed>
+output_tail: |
+  <last ~30 lines of failed output>
+attempts: <how many times you tried this iteration>
+```
+
+### budget_exceeded
+
+```yaml
+status: budget_exceeded
+spent:
+  tokens: <approx>
+  wall_clock_minutes: <approx>
+last_action: |
+  <one sentence on what you were doing when you hit the cap>
+```
+
+---
+
+## Things you do NOT do
+
+- You do not pick the next task. The controller does that.
+- You do not review your own work for spec compliance. The cold-reader does
+  that, in a separate session, with no memory of yours.
+- You do not amend the spec or design. The drift-arbiter does that, on
+  receipt of your `spec_gap` exit.
+- You do not push to remote. The controller does that after the cold-reader
+  approves.
+- You do not navigate slice boundaries. The controller halts at boundaries
+  and prompts the human.
+
+---
+
+## Style
+
+Match `CLAUDE.md` and the existing project conventions discovered in
+`context_files`. Project-specific rules ALWAYS override your defaults.
+When in doubt, mirror the precedent files literally — that's what the design
+phase chose them as the precedent for.
+
+---
+
+# Task: T-11 — StopButton component
+
+**Slice:** 1 (Minimum viable activation (one-tap → timer → STOP → saved))
+
+## Cited spec/design context
+
+### BR-12 (spec)
+
+- **BR-12** — A STOP action MUST be available throughout the active incident.
+
+### BR-13 (spec)
+
+- **BR-13** — On STOP, the timer MUST freeze at the current elapsed time and the incident MUST persist with `endedAt = now`. (Pet is always set per BR-28; no pet picker is invoked at STOP.)
+
+### §D2 (design)
+
+## §D2 Architecture
+
+Following the medications precedent (`src/features/medications/*`, `src/repositories/PetMedicationRepository.ts`, `src/services/petMedicationService.ts`, `src/store/usePetMedicationStore.ts`).
+
+### File map
+
+```
+src/features/incidents/
+  pages/
+    ActiveIncidentPage.tsx              # /incidents/active route — loads activeIncident from store, renders <IncidentCaptureSurface>
+    ActiveIncidentPage.test.tsx
+    SavedIncidentPage.tsx               # /pets/:petId/incidents/:id route — loads incident by id, renders <IncidentCaptureSurface>
+    SavedIncidentPage.test.tsx
+  components/
+    IncidentCaptureSurface.tsx          # SHARED surface used by both pages (BR-14, BR-25 — same surface live, post-stop, re-opened)
+    IncidentCaptureSurface.test.tsx
+    IncidentTimer.tsx                   # monospace hero, ticks every ~250ms (see §D8)
+    IncidentTimer.test.tsx
+    SeverityChips.tsx                   # 3-up grid (BR-6)
+    SeverityChips.test.tsx
+    ObservationChips.tsx                # type-aware grid (BR-7, BR-19, BR-32)
+    ObservationChips.test.tsx
+    IncidentJournal.tsx                 # append-only textarea (BR-8, BR-9, BR-30)
+    IncidentJournal.test.tsx
+    VetCallCard.tsx                     # tel: link (BR-10, BR-11)
+    VetCallCard.test.tsx
+    ActivationPetPicker.tsx             # bottom-Drawer picker shown when global FAB is tapped on a non-pet-scoped surface for multi-pet users (BR-28 third rule, DQ-7 resolution)
+    ActivationPetPicker.test.tsx
+    StopButton.tsx                      # (BR-12, BR-13)
+    StopButton.test.tsx
+    DeleteIncidentAction.tsx            # soft-delete trigger (BR-33)
+    DeleteIncidentAction.test.tsx
+    ResumeIncidentBanner.tsx            # global persistent banner offering to navigate to active incident (DQ-2 resolution)
+    ResumeIncidentBanner.test.tsx
+    IncidentHistoryList.tsx             # per-pet list (BR-23, BR-24, BR-25)
+    IncidentHistoryList.test.tsx
+  hooks/
+    useActiveIncident.ts                # selector + actions (start, stop, mutate, delete)
+    useActiveIncident.test.ts
+    useIncidentTimer.ts                 # rAF-driven elapsed seconds
+    useIncidentTimer.test.ts
+  types.ts                              # Incident, IncidentType, Severity, ChipId
+  chipCatalog.ts                        # static type→chips map (resolves OQ-3)
+
+src/repositories/
+  IncidentRepository.ts                 # CRUD against Firestore (NFR-8, BR-15)
+
+src/services/
+  incidentService.ts                    # business logic, composes repository
+                                        # — exposes getRecentTypesForPet(petId, limit=10): IncidentTypeId[]
+                                        #   for BR-21's MRU-per-pet sort. Implementation: query per-pet history
+                                        #   (composite index already covers it), map to types, dedupe preserving order.
+
+src/store/
+  useIncidentStore.ts                   # Zustand: activeIncident + per-pet history maps
+
+src/components/common/
+  EmergencyActivationFab.tsx            # global FAB, mounted in App.tsx (BR-27, AC-18)
+  EmergencyActivationFab.test.tsx
+```
+
+### Routes
+
+Add to `src/AppRoutes.tsx`:
+
+- `/incidents/active` → `ActiveIncidentPage` (auth-guarded; redirects to `/pets` if no active incident)
+- `/pets/:petId/incidents/:incidentId` → `SavedIncidentPage` (auth-guarded; pet-scoped per BR-23/25)
+
+Both gated behind a new `incidentsEnabled` feature flag, matching the existing pattern (`enableVets`, `enablePetList`, etc. in `src/AppRoutes.tsx:31-39`).
+
+### Global activation FAB (BR-27, AC-18)
+
+`EmergencyActivationFab` mounts in `src/App.tsx` outside the route tree so it survives navigation. Hidden when:
+
+- user is unauthenticated
+- the active route is `/incidents/active` (DQ-3 resolution: hidden — no-op there; the active surface itself owns navigation)
+- `incidentsEnabled` flag is off
+- the user has zero pets (per BR-27's round-5 zero-pet exception, added in spec to make this design behavior consistent with the requirement)
+
+Built with MUI `<Fab>`, positioned bottom-right with `position: fixed`. Tap target ≥56×56 (BR-27, NFR-3).
+
+**Tap behavior** (per BR-26 short-circuit and BR-28's three rules):
+
+| Pre-condition              | Surface                       | Pet count | Behavior                                                                                                                   |
+| -------------------------- | ----------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Active incident exists** | any                           | any       | Navigate to `/incidents/active` (resume — BR-26, AC-11). All other rules below skip.                                       |
+| No active incident         | Pet-scoped (e.g. `/pets/:id`) | any       | Activate immediately with that pet (1 tap, AC-20).                                                                         |
+| No active incident         | Non-pet-scoped                | exactly 1 | Activate immediately with the only pet (1 tap, AC-20).                                                                     |
+| No active incident         | Non-pet-scoped                | 2+        | Open `ActivationPetPicker` as an MUI bottom Drawer (DQ-7 resolution); the pet tap IS the activation (2 taps total, AC-19). |
+
+---
+
+## Verify (the per-task gate)
+
+Component test: tap fires the store action; `aria-label` matches the i18n value.
+
+## Project context files
+
+Read these for project conventions:
+- `CLAUDE.md`
+
+## Files you may create or modify
+
+_None pre-specified. Derive from the cited design §D2 file map and stage only those._
+
+## Budget
+
+- tokens: ~100,000
+- wall clock: 15 min
+- retries on verify_fail: 2

--- a/scripts/harness/evals/builder/cases/regression/round-29-T11-success-baseline.json
+++ b/scripts/harness/evals/builder/cases/regression/round-29-T11-success-baseline.json
@@ -1,0 +1,30 @@
+{
+  "case_id": "regression-round-29-T11-success-baseline",
+  "task_id": "T-11",
+  "source": "Round-29 third T-11 dispatch — first SUCCESS exit emitted live by the harness on a real slice task. Validates the full chain of round-27/28/29 fixes: dispatcher resilience (PR #169 / cherry-picked into #170), verify-command derivation rule (round-27 fix in #170), final-verify-rerun rule (round-28 fix in #170), bypassPermissions for builder (round-29 fix this PR). Cost: $0.4765, 128s, 25 turns. Produced commit fdd3113 with 2 passing tests, citation `(BR-12, BR-13)` accepted by the citation linter. First harness-driven slice-1 commit.",
+  "input": {
+    "rendered_builder_input_path": "scripts/harness/evals/builder/cases/regression/round-29-T11-success-baseline.input.md"
+  },
+  "expected": {
+    "status": "success",
+    "files_touched_pattern": "src/features/incidents/components/StopButton(\\.test)?\\.tsx",
+    "notes_pattern": "(?i)(BR-12|BR-13|aria-label|stopIncident|i18n)"
+  },
+  "actual_baseline": {
+    "status": "success",
+    "commit_sha": "fdd3113689f663be1f9b0ca94a74ccdb5615b813",
+    "files_touched": [
+      "src/features/incidents/components/StopButton.tsx",
+      "src/features/incidents/components/StopButton.test.tsx"
+    ],
+    "wall_clock_seconds": 128,
+    "tokens_consumed": null,
+    "cost_usd": 0.4765,
+    "tool_uses": null,
+    "session_id": "d0e33d47-e08e-4abc-9d91-04f727de1384",
+    "stop_reason": "end_turn",
+    "num_turns": 25,
+    "notes": "First-ever live `success` exit from the harness on a slice task. Cost is 33% lower than round-27 (Jest-syntax verify_fail at $0.71) and 30% lower than round-28 (false-negative verify_fail at $0.68) — prompt is converging. Citation `(BR-12, BR-13)` matches the citation linter's acceptable forms. Tests independently verified (2/2 pass via `pnpm exec vitest run <path>`). T-11 marked [x] in 03-tasks.md. Slice 1: 5/11 → 6/11."
+  },
+  "notes": "Companion to the verify_fail trio: round-27 (Jest-syntax verify_command), round-28 (false-negative attempt-counting), round-29 attempt 1 (bypassPermissions needed for Bash). Together the four cases trace the full empirical methodology arc on T-11 — three failures surfaced three real prompt/dispatcher bugs, each shipped as a fix; the success case validates that all four amendments compose cleanly on a real slice task. Cumulative T-11 spend: $0.71 + $0.68 + $0.65 + $0.48 = $2.52 across 4 dispatches, with 1 commit. The methodology fixes shipped along the way are the load-bearing return; the cost-per-success will continue to drop as the prompt stabilizes through T-12..T-15."
+}

--- a/scripts/harness/lib/dispatch/builder-dispatch.ts
+++ b/scripts/harness/lib/dispatch/builder-dispatch.ts
@@ -7,7 +7,9 @@
  *
  * The builder is configured with:
  *   - model: sonnet (project default for the role)
- *   - permissionMode: acceptEdits (it WILL write code + run verify + commit)
+ *   - permissionMode: bypassPermissions (it WILL write code + run verify + commit;
+ *     `acceptEdits` only auto-accepts file edits and blocks Bash, which made
+ *     the subagent unable to run its own verify gate — round-29 finding)
  *   - disallowedTools: blanket Bash deny on infra-deploy commands as a
  *     belt-and-suspenders backup to the round-25 builder.md no-deploy rule
  */
@@ -70,7 +72,7 @@ export interface BuilderDispatchOptions {
   taskListPath?: string;
   /** Builder system prompt path (defaults to scripts/harness/lib/prompts/builder.md). */
   promptPath?: string;
-  /** Override permission mode (default: acceptEdits). */
+  /** Override permission mode (default: bypassPermissions, with disallowedTools as the safety net). */
   permissionMode?: 'acceptEdits' | 'bypassPermissions' | 'plan';
   /** Override timeout (default: 30 minutes for builder). */
   timeoutMs?: number;
@@ -136,7 +138,7 @@ export async function dispatchBuilder(
   const raw = await dispatchSubagent({
     prompt: fullPrompt,
     model: 'sonnet',
-    permissionMode: opts.permissionMode ?? 'acceptEdits',
+    permissionMode: opts.permissionMode ?? 'bypassPermissions',
     disallowedTools: DEFAULT_DISALLOWED_TOOLS,
     cwd: opts.cwd,
     timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,

--- a/src/features/incidents/components/StopButton.test.tsx
+++ b/src/features/incidents/components/StopButton.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StopButton } from './StopButton';
+import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@store/useIncidentStore');
+
+describe('StopButton', () => {
+  const mockStopIncident = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      stopIncident: mockStopIncident,
+    } as unknown as IncidentState);
+  });
+
+  it('tap fires the stopIncident store action (BR-12, BR-13)', async () => {
+    const user = userEvent.setup();
+    render(<StopButton />);
+
+    await user.click(screen.getByRole('button', { name: 'incidents.stop' }));
+
+    expect(mockStopIncident).toHaveBeenCalledTimes(1);
+  });
+
+  it('aria-label matches the i18n value (BR-12)', () => {
+    render(<StopButton />);
+
+    expect(
+      screen.getByRole('button', { name: 'incidents.stop' })
+    ).toHaveAttribute('aria-label', 'incidents.stop');
+  });
+});

--- a/src/features/incidents/components/StopButton.tsx
+++ b/src/features/incidents/components/StopButton.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useIncidentStore } from '@store/useIncidentStore';
+
+export function StopButton() {
+  const { t } = useTranslation();
+  const { stopIncident } = useIncidentStore();
+  const label = t('incidents.stop');
+
+  return (
+    <Button
+      variant="contained"
+      color="error"
+      aria-label={label}
+      onClick={() => void stopIncident()}
+    >
+      {label}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

Round 29 found the **fourth** real bug in the harness across rounds 27-29 — and (drumroll) shipped the **first ever live `success` exit on a slice task**.

## The two commits in this PR

### `fdd3113` — feat: T-11 StopButton (the subagent's own commit)

The first slice-1 commit produced by `harness build` end-to-end. Subagent wrote MUI Button + 2 unit tests, ran verify cleanly, committed with citation `(BR-12, BR-13)`. Tests independently re-verified: 2/2 pass.

### `1c459cf` — chore: builder bypassPermissions + round-29 evidence

The fix that got the success commit to land. Round-29 attempt 1 produced PARSE_FAILED at $0.65 / 176s / 24 turns. Subagent wrote the same StopButton code, then **stopped at the verify gate** and emitted: _"I need approval to run tests. Please approve running `pnpm exec vitest run src/features/incidents/components/StopButton.test.tsx`."_

Root cause: `acceptEdits` permission mode auto-accepts file edits but **blocks Bash**. The subagent could write code but couldn't run its own verify gate. The dispatcher's round-27 raw-on-parse-failure capture (PR #169) is what made this finding visible — without it, attempt 1 would have been a silent failure like rounds 27 attempt 1.

Switched builder default to `bypassPermissions`. The `disallowedTools` deny list (firebase deploy, vercel deploy, gcloud, kubectl apply, terraform apply) is the safety boundary; the round-25 builder.md no-deploy rule is the prompt-level reinforcement. Together they cover the dangerous-Bash surface without blocking the verify gate the subagent needs to run.

## Round-29 attempt 2 result (the success)

```
exit:     success
cost:     $0.4765
duration: 128s
turns:    25
commit:   fdd3113
```

**Cost dropped 33% vs round-27 ($0.71) and 30% vs round-28 ($0.68) — prompt is converging.**

## Evidence + new fixtures

- `scripts/harness/evals/builder/cases/regression/round-29-T11-success-baseline.{json,input.md}` — first success-case fixture in the regression suite (10 → 11 cases). `expected.status: success` with files_touched_pattern + notes_pattern. Captures the converged-prompt baseline.
- `round-29-T11-evidence/StopButton-attempt-1.{tsx,test.tsx}.txt` — the parse_failed evidence; subagent's code was correct, only the verify gate failed.

## Cumulative T-11 spend across rounds 27-29

| Round | Attempt | Outcome | Cost | Cause | Fix shipped |
|-------|---------|---------|------|-------|-------------|
| 27 | 1 | parse_error (silent) | n/a | parser threw | dispatcher resilience (#169) |
| 27 | 2 | verify_fail | $0.71 | Jest CLI syntax on Vitest | verify-command derivation rule (#170) |
| 28 | 1 | verify_fail (false negative) | $0.68 | counted RED-phase failures | final-verify-rerun rule (#170) |
| 29 | 1 | parse_error → "needs approval" | $0.65 | acceptEdits blocks Bash | bypassPermissions (this PR) |
| **29** | **2** | **success ✓** | **$0.48** | — | **commit fdd3113 in this PR** |

**Total: $2.52 across 4 dispatches, 1 commit.** The methodology fixes shipped along the way are the load-bearing return.

## Slice 1 status: 5/11 → 6/11

T-11 marked `[x]` in `03-tasks.md`. Remaining: T-12 (IncidentCaptureSurface), T-13 (ActiveIncidentPage), T-14 (EmergencyActivationFab), T-15 (Routes + App.tsx mount), T-16 (manual smoke).

## Verify

- `pnpm preflight` clean (lint + knip + build + test:coverage)
- `pnpm exec vitest run src/features/incidents/components/StopButton.test.tsx`: 2/2 PASS
- 11 builder eval cases load + validate (was 10)

## Test plan

- [ ] CI green
- [ ] Reviewer reads the bypassPermissions justification in `builder-dispatch.ts`
- [ ] Reviewer skims commit `fdd3113` to confirm the subagent's StopButton matches T-11's task body

## Carry-overs (round 30+)

- Re-dispatch on T-12 next; expect cleaner cost (target <$0.40 if the prompt is fully converged)
- If T-12..T-15 all dispatch cleanly → slice 1 ships fully harness-driven through T-16 manual smoke
- Long-tail: state.json event log, controller orchestration loop (build → review → arbitrate → re-dispatch automation)