### PR TITLE
feat(harness): orchestrator round 1 — chain build → review → (arbiter+apply)

### DIFF
--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -79,7 +79,9 @@ Override via opts on `dispatchBuilder`/`dispatchColdReader`/`dispatchArbiter` if
 
 ### State persistence
 
-Not yet implemented. Each dispatch is currently stateless — no `.harness/state.json`, no event log, no retry tracking across invocations. The next iteration will add an append-only event log so the controller can resume mid-slice and produce per-PR cost/duration reports.
+`harness orchestrate` writes `.harness/state.json` (gitignored) as an append-only event log: one event per dispatch, plus `amendment_applied` / `amendment_apply_failed` / `cycle_halt` markers. Per-task summary (cost, dispatches, halt reason) is reconstructible from the log via `summarizeRun()` in `lib/state-store.ts`.
+
+Resume mid-cycle is **not** supported in v1 — the log is purely an audit trail. The individual `build`/`review`/`arbitrate-run` commands remain stateless.
 
 ## Eval suites
 

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -38,6 +38,27 @@ pnpm tsx scripts/harness/cli.ts review T-11 --diff main..HEAD
 pnpm tsx scripts/harness/cli.ts arbitrate-run gap.json
 ```
 
+## Orchestrator (round 1)
+
+Chains build → review → (arbiter+apply) automatically. Logs every step to `.harness/state.json` (gitignored).
+
+```bash
+pnpm tsx scripts/harness/cli.ts orchestrate T-14
+```
+
+**v1 routing:**
+
+- Build success → cold-reader. Approve → done. Veto routes by `scope_check`:
+  - `1, 2` (builder error: BR not implemented, AC not asserted) → **halt for human**. v1 doesn't auto-retry builder with veto context.
+  - `3, 4, 5, 6` (spec/design ambiguity) → arbiter → apply amendment via deterministic `before` → `after` substitution → re-dispatch builder → re-cold-read.
+- Build `spec_gap` → arbiter directly.
+- Arbiter `pushback` → halt for human (v1 doesn't feed pushback into builder input).
+- Apply-amendment failure (before doesn't match exactly, or matches >1) → halt for human.
+
+**Caps:** 2 builder retries (3 total), 2 arbiter dispatches, $5 / 30 min total. Halts for human on cap.
+
+**State:** every event lands in `.harness/state.json` as an append-only log. Resume mid-cycle is NOT supported in v1; the log is purely an audit trail (cost, dispatches, amendments, halt reason).
+
 Each command supports `--json` for machine-readable output (suitable for piping into another tool).
 
 ### Dispatch defaults

--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -42,6 +42,10 @@ import { parseTaskList } from './lib/task-parser.ts';
 import { dispatchBuilder } from './lib/dispatch/builder-dispatch.ts';
 import { dispatchColdReader } from './lib/dispatch/cold-reader-dispatch.ts';
 import { dispatchArbiter } from './lib/dispatch/arbiter-dispatch.ts';
+import {
+  orchestrateTask,
+  summarizeOrchestrateResult,
+} from './lib/orchestrate.ts';
 import { dirname, join } from 'node:path';
 import { execSync } from 'node:child_process';
 
@@ -76,6 +80,9 @@ function usage(): string {
     '                             HEAD~1..HEAD).',
     '  arbitrate-run <spec-gap-file>',
     '                             Dispatch a drift-arbiter subagent on the gap.',
+    '  orchestrate <task-id>      Chain build → review → (arbiter+apply) until',
+    '                             success, halt for human, or hit a cap. Logs',
+    '                             every step to .harness/state.json.',
     '',
     'Options:',
     `  --file <path>              Task list to read (default: ${DEFAULT_TASK_FILE}).`,
@@ -540,6 +547,19 @@ function main(): void {
       );
       break;
     }
+    case 'orchestrate': {
+      const taskId = positionals[1];
+      if (!taskId) {
+        fail('orchestrate requires a task id (e.g. T-14)\n\n' + usage());
+      }
+      void runOrchestrate(taskId, filePath, fileArg, values.json).catch(
+        (err) => {
+          const reason = err instanceof Error ? err.message : String(err);
+          fail(`orchestrate failed: ${reason}`);
+        }
+      );
+      break;
+    }
     default:
       fail(`unknown command '${command}'\n\n${usage()}`);
   }
@@ -737,6 +757,44 @@ async function runArbitrate(
     }
   }
   process.exit(0);
+}
+
+async function runOrchestrate(
+  taskId: string,
+  filePath: string,
+  fileArg: string,
+  json: boolean
+): Promise<void> {
+  process.stderr.write(
+    `harness: orchestrating ${taskId} — chained build → review → (arbiter) loop. This may take 5-15 minutes.\n`
+  );
+  const result = await orchestrateTask({
+    taskId,
+    taskListPath: filePath,
+  });
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          file: fileArg,
+          task_id: taskId,
+          outcome: result.outcome,
+          builder_dispatches: result.builderDispatches,
+          arbiter_dispatches: result.arbiterDispatches,
+          total_cost_usd: result.totalCostUsd,
+          last_commit_sha: result.lastCommitSha,
+          halt_reason: result.haltReason,
+          state_path: '.harness/state.json',
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    process.stdout.write(`${summarizeOrchestrateResult(result)}\n`);
+    process.stdout.write(`state log: .harness/state.json\n`);
+  }
+  process.exit(result.outcome === 'success' ? 0 : 2);
 }
 
 main();

--- a/scripts/harness/lib/dispatch/apply-amendment.test.ts
+++ b/scripts/harness/lib/dispatch/apply-amendment.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { applyAmendment } from './apply-amendment';
+import type { ArbiterAmendment } from './arbiter-dispatch';
+
+let workDir: string;
+let specDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'harness-amend-'));
+  specDir = join(workDir, 'docs/specs/incident-capture');
+  mkdirSync(specDir, { recursive: true });
+});
+
+const DESIGN_FIXTURE = `# Design
+
+## §D2 Architecture
+
+\`\`\`
+src/
+  store/
+    useIncidentStore.ts                   # Zustand: activeIncident
+\`\`\`
+
+## §D11 Design Changelog
+
+- **2026-05-01** — Initial draft.
+- **2026-05-02 round 25** — Amended §D3.
+`;
+
+function writeFixture(name: string, body: string): void {
+  writeFileSync(join(specDir, name), body, 'utf8');
+}
+
+describe('applyAmendment', () => {
+  it('applies a clean before→after substitution and appends changelog entry', () => {
+    writeFixture('02-design.md', DESIGN_FIXTURE);
+    const amendment: ArbiterAmendment = {
+      file: '02-design.md',
+      anchor: '§D2 useIncidentStore.ts comment',
+      before:
+        '    useIncidentStore.ts                   # Zustand: activeIncident',
+      after:
+        '    useIncidentStore.ts                   # Zustand: activeIncident.\n                                            # Post-STOP keeps activeIncident set.',
+      changelog_entry:
+        '**2026-05-02 round 31** — Amended §D2 file map for post-STOP store invariant.',
+    };
+
+    const result = applyAmendment(amendment, { specDir });
+    expect(result.ok).toBe(true);
+    expect(result.changelog_appended_at_eof).toBe(false);
+
+    const updated = readFileSync(join(specDir, '02-design.md'), 'utf8');
+    expect(updated).toContain('Post-STOP keeps activeIncident set.');
+    expect(updated).toContain('round 31');
+    // Original content preserved
+    expect(updated).toContain('Initial draft');
+    // Changelog entry inside the §D11 block, before EOF
+    const d11Idx = updated.indexOf('## §D11');
+    expect(d11Idx).toBeGreaterThan(0);
+    expect(updated.slice(d11Idx)).toContain('round 31');
+  });
+
+  it('refuses when before does not match exactly', () => {
+    writeFixture('02-design.md', DESIGN_FIXTURE);
+    const amendment: ArbiterAmendment = {
+      file: '02-design.md',
+      anchor: '§D2',
+      before: 'this text is not in the file',
+      after: 'replacement',
+      changelog_entry: '2026-05-02 — never applied',
+    };
+
+    const result = applyAmendment(amendment, { specDir });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/);
+    // File is untouched
+    expect(readFileSync(join(specDir, '02-design.md'), 'utf8')).toBe(
+      DESIGN_FIXTURE
+    );
+  });
+
+  it('refuses when before matches multiple times (ambiguous)', () => {
+    writeFixture(
+      '02-design.md',
+      `${DESIGN_FIXTURE}\n\nDuplicate marker.\nDuplicate marker.\n`
+    );
+    const amendment: ArbiterAmendment = {
+      file: '02-design.md',
+      anchor: '§D2',
+      before: 'Duplicate marker.',
+      after: 'Replaced.',
+      changelog_entry: '2026-05-02 — never applied',
+    };
+
+    const result = applyAmendment(amendment, { specDir });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/matches 2 times/);
+  });
+
+  it('refuses pure additions (empty before) in v1', () => {
+    writeFixture('02-design.md', DESIGN_FIXTURE);
+    const amendment: ArbiterAmendment = {
+      file: '02-design.md',
+      anchor: '§D2',
+      before: '',
+      after: 'pure addition',
+      changelog_entry: '2026-05-02 — never applied',
+    };
+    const result = applyAmendment(amendment, { specDir });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/pure additions/);
+  });
+
+  it('appends changelog at EOF when block header is missing (with warning marker)', () => {
+    writeFixture(
+      '02-design.md',
+      '# Design\n\n## §D2 Architecture\n\nuseIncidentStore.ts comment\n'
+    );
+    const amendment: ArbiterAmendment = {
+      file: '02-design.md',
+      anchor: '§D2',
+      before: 'useIncidentStore.ts comment',
+      after: 'useIncidentStore.ts amended comment',
+      changelog_entry: '2026-05-02 — orphan changelog',
+    };
+    const result = applyAmendment(amendment, { specDir });
+    expect(result.ok).toBe(true);
+    expect(result.changelog_appended_at_eof).toBe(true);
+    const updated = readFileSync(join(specDir, '02-design.md'), 'utf8');
+    expect(updated).toContain('changelog block not found');
+    expect(updated).toContain('orphan changelog');
+  });
+
+  it('routes changelog by filename', () => {
+    writeFixture(
+      '01-spec.md',
+      '# Spec\n\nBR-7 text\n\n## §10 Spec Changelog\n\n- **2026-05-01** — initial.\n'
+    );
+    const amendment: ArbiterAmendment = {
+      file: '01-spec.md',
+      anchor: 'BR-7',
+      before: 'BR-7 text',
+      after: 'BR-7 amended text',
+      changelog_entry: '2026-05-02 — clarify BR-7',
+    };
+    const result = applyAmendment(amendment, { specDir });
+    expect(result.ok).toBe(true);
+    expect(result.changelog_appended_at_eof).toBe(false);
+    const updated = readFileSync(join(specDir, '01-spec.md'), 'utf8');
+    expect(updated.indexOf('## §10')).toBeLessThan(
+      updated.indexOf('clarify BR-7')
+    );
+  });
+
+  it('returns error when target file does not exist', () => {
+    const amendment: ArbiterAmendment = {
+      file: '99-nonexistent.md',
+      anchor: 'X',
+      before: 'a',
+      after: 'b',
+      changelog_entry: 'x',
+    };
+    const result = applyAmendment(amendment, { specDir });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/file not found/);
+  });
+});

--- a/scripts/harness/lib/dispatch/apply-amendment.ts
+++ b/scripts/harness/lib/dispatch/apply-amendment.ts
@@ -1,0 +1,145 @@
+/**
+ * Apply an arbiter amendment to a spec/design/task file.
+ *
+ * The amendment is a deterministic before/after substring substitution plus
+ * a changelog entry append. Pre-apply guard: `before` MUST appear exactly
+ * once in the file. If it doesn't (whitespace drift, prior overlapping
+ * amendment, ambiguous match), the function returns an error and the
+ * orchestrator halts for human intervention.
+ *
+ * Changelog routing:
+ *   01-spec.md   → §10 Spec Changelog
+ *   02-design.md → §D11 Design Changelog
+ *   03-tasks.md  → §T0 Tasks Changelog
+ *
+ * If the changelog block can't be located, the entry is appended at EOF
+ * with a warning, and the result records `changelog_appended_at_eof: true`.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import type { ArbiterAmendment } from './arbiter-dispatch';
+
+export interface ApplyAmendmentResult {
+  ok: boolean;
+  /** Absolute path written. */
+  filePath?: string;
+  /** Why the apply failed (when ok=false). */
+  error?: string;
+  /** True when the changelog landed at EOF rather than the canonical block. */
+  changelog_appended_at_eof?: boolean;
+  /** True when amendment.before was empty (pure addition); applied at EOF of the section. */
+  pure_addition?: boolean;
+}
+
+const CHANGELOG_HEADERS_BY_FILE: Record<string, string[]> = {
+  '01-spec.md': ['## §10 Spec Changelog', '## §10', '## §10 Changelog'],
+  '02-design.md': ['## §D11 Design Changelog', '## §D11'],
+  '03-tasks.md': ['## §T0 Tasks Changelog', '## §T0'],
+};
+
+export function applyAmendment(
+  amendment: ArbiterAmendment,
+  opts: { repoRoot?: string; specDir?: string } = {}
+): ApplyAmendmentResult {
+  const repoRoot = opts.repoRoot ?? process.cwd();
+  const specDir =
+    opts.specDir ?? resolve(repoRoot, 'docs/specs/incident-capture');
+  const filePath = resolve(specDir, amendment.file);
+
+  if (!existsSync(filePath)) {
+    return {
+      ok: false,
+      error: `apply-amendment: file not found at ${filePath}`,
+    };
+  }
+
+  const original = readFileSync(filePath, 'utf8');
+
+  let updated: string;
+  if (amendment.before === '') {
+    // Pure addition — append to anchor section is ambiguous without an
+    // explicit insertion point. v1: refuse pure-addition amendments and
+    // require the arbiter to send a non-empty `before`. (The arbiter's
+    // current prompt does emit non-empty `before` in practice.)
+    return {
+      ok: false,
+      error:
+        'apply-amendment: pure additions (empty `before`) are not supported in v1; arbiter must include a non-empty before string',
+    };
+  } else {
+    const matches = countOccurrences(original, amendment.before);
+    if (matches === 0) {
+      return {
+        ok: false,
+        error: `apply-amendment: amendment.before not found in ${basename(filePath)}. Likely cause: whitespace drift or prior overlapping amendment.`,
+      };
+    }
+    if (matches > 1) {
+      return {
+        ok: false,
+        error: `apply-amendment: amendment.before matches ${matches} times in ${basename(filePath)}; ambiguous. Arbiter must send a more specific anchor.`,
+      };
+    }
+    updated = original.replace(amendment.before, amendment.after);
+  }
+
+  const changelogResult = appendChangelogEntry(
+    updated,
+    amendment.file,
+    amendment.changelog_entry
+  );
+  updated = changelogResult.text;
+
+  writeFileSync(filePath, updated, 'utf8');
+  return {
+    ok: true,
+    filePath,
+    changelog_appended_at_eof: changelogResult.appendedAtEof,
+  };
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle === '') return 0;
+  let count = 0;
+  let idx = 0;
+  while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+    count += 1;
+    idx += needle.length;
+  }
+  return count;
+}
+
+function appendChangelogEntry(
+  fileText: string,
+  fileBasename: string,
+  entry: string
+): { text: string; appendedAtEof: boolean } {
+  const headers = CHANGELOG_HEADERS_BY_FILE[fileBasename] ?? [];
+  for (const header of headers) {
+    const idx = fileText.indexOf(header);
+    if (idx !== -1) {
+      // Append the entry as a new bullet line at the END of the changelog
+      // block. The block is everything from the header to the next H2 or EOF.
+      const afterHeader = idx + header.length;
+      const nextH2 = fileText.indexOf('\n## ', afterHeader);
+      const blockEnd = nextH2 === -1 ? fileText.length : nextH2;
+      const block = fileText.slice(afterHeader, blockEnd);
+      // Trim trailing whitespace from the block and append the entry.
+      const trimmedBlock = block.replace(/\s+$/, '');
+      const newBlock = `${trimmedBlock}\n- ${entry}\n`;
+      return {
+        text:
+          fileText.slice(0, afterHeader) + newBlock + fileText.slice(blockEnd),
+        appendedAtEof: false,
+      };
+    }
+  }
+  // Fallback: append at EOF with a warning marker.
+  return {
+    text:
+      fileText.replace(/\s*$/, '') +
+      `\n\n<!-- changelog block not found -->\n- ${entry}\n`,
+    appendedAtEof: true,
+  };
+}

--- a/scripts/harness/lib/orchestrate.test.ts
+++ b/scripts/harness/lib/orchestrate.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { orchestrateTask, type OrchestrateDeps } from './orchestrate';
+import type {
+  BuilderDispatchResult,
+  BuilderExit,
+} from './dispatch/builder-dispatch';
+import type {
+  ColdReaderDispatchResult,
+  ColdReaderExit,
+} from './dispatch/cold-reader-dispatch';
+import type {
+  ArbiterDispatchResult,
+  ArbiterExit,
+} from './dispatch/arbiter-dispatch';
+import type { ApplyAmendmentResult } from './dispatch/apply-amendment';
+import type { DispatchResult } from './subagent-dispatch';
+
+let workDir: string;
+let statePath: string;
+let specDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'orchestrate-'));
+  statePath = join(workDir, '.harness/state.json');
+  specDir = join(workDir, 'docs/specs/incident-capture');
+  mkdirSync(specDir, { recursive: true });
+  writeFileSync(join(specDir, '02-design.md'), '# Design\n', 'utf8');
+});
+
+function rawEnvelope(costUsd: number, durationMs = 1000): DispatchResult {
+  return {
+    resultText: '<mocked>',
+    isError: false,
+    costUsd,
+    durationMs,
+    numTurns: 5,
+    sessionId: `session-${Math.random().toString(36).slice(2, 8)}`,
+    stopReason: 'end_turn',
+    rawEnvelope: {},
+  };
+}
+
+function builderSuccess(
+  commitSha: string,
+  costUsd = 0.5
+): BuilderDispatchResult {
+  return {
+    exit: { status: 'success', commit_sha: commitSha } as BuilderExit,
+    raw: rawEnvelope(costUsd),
+  };
+}
+function builderSpecGap(
+  cite: string,
+  desc: string,
+  costUsd = 0.6
+): BuilderDispatchResult {
+  return {
+    exit: {
+      status: 'spec_gap',
+      cited_section: cite,
+      gap_description: desc,
+    } as BuilderExit,
+    raw: rawEnvelope(costUsd),
+  };
+}
+function builderVerifyFail(costUsd = 0.7): BuilderDispatchResult {
+  return {
+    exit: {
+      status: 'verify_fail',
+      verify_command: 'pnpm exec vitest',
+      attempts: 3,
+    } as BuilderExit,
+    raw: rawEnvelope(costUsd),
+  };
+}
+function reviewApprove(costUsd = 0.27): ColdReaderDispatchResult {
+  return {
+    exit: {
+      task_id: 'T-N',
+      verdict: 'approve',
+      findings: [],
+    } as ColdReaderExit,
+    raw: rawEnvelope(costUsd),
+  };
+}
+function reviewVeto(
+  scopeCheck: 1 | 2 | 3 | 4 | 5 | 6,
+  cite: string,
+  costUsd = 0.27
+): ColdReaderDispatchResult {
+  return {
+    exit: {
+      task_id: 'T-N',
+      verdict: 'veto',
+      findings: [
+        {
+          severity: 'HIGH',
+          scope_check: scopeCheck,
+          cited_section: cite,
+          evidence: 'fake-file:1',
+          description: `mock veto on scope ${scopeCheck}`,
+        },
+      ],
+    } as ColdReaderExit,
+    raw: rawEnvelope(costUsd),
+  };
+}
+function arbiterAmendDesign(
+  before: string,
+  after: string,
+  costUsd = 0.3
+): ArbiterDispatchResult {
+  return {
+    exit: {
+      verdict: 'amend_design',
+      amendment: {
+        file: '02-design.md',
+        anchor: 'mock anchor',
+        before,
+        after,
+        changelog_entry: '2026-05-02 — mock amendment',
+      },
+    } as ArbiterExit,
+    raw: rawEnvelope(costUsd),
+  };
+}
+function arbiterPushback(costUsd = 0.3): ArbiterDispatchResult {
+  return {
+    exit: {
+      verdict: 'pushback',
+      pushback_clarification: 'builder misread; chips are out of scope',
+    } as ArbiterExit,
+    raw: rawEnvelope(costUsd),
+  };
+}
+
+function makeDeps(overrides: Partial<OrchestrateDeps> = {}): OrchestrateDeps {
+  return {
+    dispatchBuilder: vi.fn(),
+    dispatchColdReader: vi.fn(),
+    dispatchArbiter: vi.fn(),
+    applyAmendment: vi.fn(
+      (): ApplyAmendmentResult => ({ ok: true, filePath: 'mock' })
+    ),
+    resolveHeadSha: () => 'commit-abc',
+    ...overrides,
+  };
+}
+
+describe('orchestrateTask — happy path', () => {
+  it('build success → review approve → outcome=success', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValue(builderSuccess('abc123')),
+      dispatchColdReader: vi.fn().mockResolvedValue(reviewApprove()),
+    });
+
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+
+    expect(result.outcome).toBe('success');
+    expect(result.builderDispatches).toBe(1);
+    expect(result.arbiterDispatches).toBe(0);
+    expect(result.lastCommitSha).toBe('abc123');
+    expect(result.totalCostUsd).toBeCloseTo(0.77); // 0.5 + 0.27
+    expect(deps.dispatchBuilder).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchColdReader).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchArbiter).not.toHaveBeenCalled();
+  });
+});
+
+describe('orchestrateTask — full escalation cycle', () => {
+  it('build success → review veto scope 4 → arbiter amend_design → apply → re-build → re-review approve', async () => {
+    writeFixture('02-design.md', '# Design\n\nbefore-marker\n');
+    const deps = makeDeps({
+      dispatchBuilder: vi
+        .fn()
+        .mockResolvedValueOnce(builderSuccess('first-commit'))
+        .mockResolvedValueOnce(builderSuccess('second-commit')),
+      dispatchColdReader: vi
+        .fn()
+        .mockResolvedValueOnce(reviewVeto(4, '§D2'))
+        .mockResolvedValueOnce(reviewApprove()),
+      dispatchArbiter: vi
+        .fn()
+        .mockResolvedValueOnce(
+          arbiterAmendDesign('before-marker', 'after-marker')
+        ),
+    });
+
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+
+    expect(result.outcome).toBe('success');
+    expect(result.builderDispatches).toBe(2);
+    expect(result.arbiterDispatches).toBe(1);
+    expect(result.lastCommitSha).toBe('second-commit');
+    expect(deps.applyAmendment).toHaveBeenCalledTimes(1);
+    const amendmentCalls = (deps.applyAmendment as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    expect(amendmentCalls[0]?.[0].before).toBe('before-marker');
+  });
+});
+
+describe('orchestrateTask — scope-1/2 veto halts for human', () => {
+  it('build success → review veto scope 2 → halt_builder_error_veto', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValue(builderSuccess('abc')),
+      dispatchColdReader: vi.fn().mockResolvedValue(reviewVeto(2, 'AC-3')),
+    });
+
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+
+    expect(result.outcome).toBe('halt_builder_error_veto');
+    expect(result.haltReason).toMatch(/scope_check 2/);
+    expect(deps.dispatchArbiter).not.toHaveBeenCalled();
+  });
+
+  it('scope 1 also halts', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValue(builderSuccess('abc')),
+      dispatchColdReader: vi.fn().mockResolvedValue(reviewVeto(1, 'BR-12')),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+    expect(result.outcome).toBe('halt_builder_error_veto');
+  });
+});
+
+describe('orchestrateTask — builder spec_gap → arbiter directly', () => {
+  it('skips cold-reader and goes straight to arbiter', async () => {
+    writeFixture('02-design.md', '# Design\n\nbefore\n');
+    const deps = makeDeps({
+      dispatchBuilder: vi
+        .fn()
+        .mockResolvedValueOnce(builderSpecGap('§D3', 'gap'))
+        .mockResolvedValueOnce(builderSuccess('post-amend-commit')),
+      dispatchArbiter: vi
+        .fn()
+        .mockResolvedValueOnce(arbiterAmendDesign('before', 'after')),
+      dispatchColdReader: vi.fn().mockResolvedValueOnce(reviewApprove()),
+    });
+
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+
+    expect(result.outcome).toBe('success');
+    expect(deps.dispatchColdReader).toHaveBeenCalledTimes(1); // only after re-build
+  });
+});
+
+describe('orchestrateTask — arbiter pushback halts in v1', () => {
+  it('halt_pushback_unsupported with clarification surfaced', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi
+        .fn()
+        .mockResolvedValueOnce(builderSpecGap('§D3', 'gap')),
+      dispatchArbiter: vi.fn().mockResolvedValueOnce(arbiterPushback()),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+    expect(result.outcome).toBe('halt_pushback_unsupported');
+    expect(result.haltReason).toMatch(/builder misread/);
+  });
+});
+
+describe('orchestrateTask — apply-amendment failure halts', () => {
+  it('halt_amendment_apply_failed when before does not match', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi
+        .fn()
+        .mockResolvedValueOnce(builderSpecGap('§D3', 'gap')),
+      dispatchArbiter: vi
+        .fn()
+        .mockResolvedValueOnce(arbiterAmendDesign('absent', 'replacement')),
+      applyAmendment: vi.fn(
+        (): ApplyAmendmentResult => ({
+          ok: false,
+          error: 'before not found',
+        })
+      ),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+    expect(result.outcome).toBe('halt_amendment_apply_failed');
+    expect(result.haltReason).toMatch(/before not found/);
+  });
+});
+
+describe('orchestrateTask — caps', () => {
+  it('halt_retry_cap when builder dispatched maxBuilderDispatches times', async () => {
+    writeFixture('02-design.md', '# D\n\nbefore\n');
+    // Loop pattern: build success → review veto scope 4 → arbiter amend → apply → repeat
+    const deps = makeDeps({
+      dispatchBuilder: vi
+        .fn()
+        .mockResolvedValue(builderSuccess('cap-commit', 0.1)),
+      dispatchColdReader: vi.fn().mockResolvedValue(reviewVeto(4, '§D2', 0.1)),
+      dispatchArbiter: vi
+        .fn()
+        .mockResolvedValue(arbiterAmendDesign('before', 'after', 0.1)),
+      applyAmendment: vi.fn(
+        (): ApplyAmendmentResult => ({ ok: true, filePath: 'mock' })
+      ),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+      maxBuilderDispatches: 2,
+      maxArbiterDispatches: 5,
+      maxCostUsd: 100,
+    });
+    expect(result.outcome).toBe('halt_retry_cap');
+    expect(result.builderDispatches).toBe(2);
+  });
+
+  it('halt_amendment_cap when arbiter dispatched maxArbiterDispatches times', async () => {
+    writeFixture('02-design.md', '# D\n\nbefore\n');
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValue(builderSuccess('c', 0.1)),
+      dispatchColdReader: vi.fn().mockResolvedValue(reviewVeto(4, '§D2', 0.1)),
+      dispatchArbiter: vi
+        .fn()
+        .mockResolvedValue(arbiterAmendDesign('before', 'after', 0.1)),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+      maxBuilderDispatches: 10,
+      maxArbiterDispatches: 1,
+      maxCostUsd: 100,
+    });
+    expect(result.outcome).toBe('halt_amendment_cap');
+    expect(result.arbiterDispatches).toBe(1);
+  });
+
+  it('halt_cost_cap when total cost exceeds budget', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValueOnce(builderSuccess('a', 5.0)),
+      dispatchColdReader: vi.fn(),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+      maxCostUsd: 1.0,
+    });
+    expect(result.outcome).toBe('halt_cost_cap');
+    // cold-reader should NOT have been called because cost was checked first
+    expect(deps.dispatchColdReader).not.toHaveBeenCalled();
+  });
+});
+
+describe('orchestrateTask — verify_fail / parse failures', () => {
+  it('builder verify_fail halts immediately', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValueOnce(builderVerifyFail()),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+    expect(result.outcome).toBe('halt_verify_fail');
+  });
+
+  it('builder parse_error halts as verify_fail', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValueOnce({
+        exit: null,
+        raw: rawEnvelope(0.5),
+        parseError: 'no status field',
+      }),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+    expect(result.outcome).toBe('halt_verify_fail');
+    expect(result.haltReason).toMatch(/parse_error/);
+  });
+});
+
+describe('orchestrateTask — state.json correctness', () => {
+  it('writes orchestrate_start, dispatch_*, orchestrate_end events in order', async () => {
+    const deps = makeDeps({
+      dispatchBuilder: vi.fn().mockResolvedValueOnce(builderSuccess('x')),
+      dispatchColdReader: vi.fn().mockResolvedValueOnce(reviewApprove()),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+    const types = result.state.events.map((e) => e.type);
+    expect(types).toEqual([
+      'orchestrate_start',
+      'dispatch_start',
+      'dispatch_end',
+      'dispatch_start',
+      'dispatch_end',
+      'orchestrate_end',
+    ]);
+  });
+
+  it('records amendment_applied event on successful application', async () => {
+    writeFixture('02-design.md', '# D\n\nbefore\n');
+    const deps = makeDeps({
+      dispatchBuilder: vi
+        .fn()
+        .mockResolvedValueOnce(builderSpecGap('§D3', 'gap'))
+        .mockResolvedValueOnce(builderSuccess('post')),
+      dispatchArbiter: vi
+        .fn()
+        .mockResolvedValueOnce(arbiterAmendDesign('before', 'after')),
+      dispatchColdReader: vi.fn().mockResolvedValueOnce(reviewApprove()),
+    });
+    const result = await orchestrateTask({
+      taskId: 'T-14',
+      statePath,
+      cwd: workDir,
+      deps,
+    });
+    const types = result.state.events.map((e) => e.type);
+    expect(types).toContain('amendment_applied');
+  });
+});
+
+function writeFixture(name: string, body: string): void {
+  writeFileSync(join(specDir, name), body, 'utf8');
+}

--- a/scripts/harness/lib/orchestrate.ts
+++ b/scripts/harness/lib/orchestrate.ts
@@ -1,0 +1,506 @@
+/**
+ * Orchestrator round 1.
+ *
+ * Chains build → review → arbitrate → apply → rebuild loops with explicit
+ * halt policies. Stateless within a single orchestrateTask call, but logs
+ * every dispatch + amendment to .harness/state.json for audit.
+ *
+ * v1 scope:
+ *   - Build success → cold-reader → approve = done; veto routes by scope_check
+ *   - Cold-reader veto on scope_check 1, 2 (builder error) → halt for human.
+ *     Re-dispatching builder with veto context isn't supported in v1
+ *     (would require extending dispatchBuilder to accept extra context).
+ *   - Cold-reader veto on scope_check 3, 4, 5, 6 (spec/design ambiguity) →
+ *     escalate to arbiter; apply amendment via deterministic before/after
+ *     substitution; re-dispatch builder; re-review.
+ *   - Builder spec_gap → escalate to arbiter directly.
+ *   - Arbiter pushback → re-dispatch builder (clarification appended via the
+ *     arbiter prompt's `pushback_clarification`; v1 does not feed this back
+ *     into the builder input — same limit as scope-1/2 veto).
+ *   - Caps: 2 builder retries, 2 arbiter amendments per task, $5 / 30 min.
+ *   - On any cap, halt for human with full state + summary.
+ */
+
+import {
+  dispatchBuilder,
+  type BuilderDispatchResult,
+  type BuilderExit,
+} from './dispatch/builder-dispatch';
+import {
+  dispatchColdReader,
+  type ColdReaderDispatchResult,
+  type ColdReaderExit,
+  type ColdReaderFinding,
+} from './dispatch/cold-reader-dispatch';
+import {
+  dispatchArbiter,
+  type ArbiterDispatchResult,
+  type ArbiterExit,
+} from './dispatch/arbiter-dispatch';
+import { applyAmendment } from './dispatch/apply-amendment';
+import type { SpecGapPayload } from './drift-arbiter-input';
+import {
+  appendEvent,
+  defaultStatePath,
+  initState,
+  loadState,
+  summarizeRun,
+  type OrchestratorState,
+} from './state-store';
+import { execSync } from 'node:child_process';
+
+export type OrchestrateOutcome =
+  | 'success'
+  | 'halt_builder_error_veto'
+  | 'halt_builder_spec_gap_unresolved'
+  | 'halt_verify_fail'
+  | 'halt_budget_exceeded'
+  | 'halt_amendment_apply_failed'
+  | 'halt_retry_cap'
+  | 'halt_amendment_cap'
+  | 'halt_cost_cap'
+  | 'halt_pushback_unsupported';
+
+export interface OrchestrateOptions {
+  taskId: string;
+  /** Override state path (default: .harness/state.json under cwd). */
+  statePath?: string;
+  /** Override spec/task list paths. */
+  taskListPath?: string;
+  /** Working directory. */
+  cwd?: string;
+  /** Cap: max total cost across all dispatches (USD). Default $5. */
+  maxCostUsd?: number;
+  /** Cap: max builder dispatches per task (initial + retries). Default 3. */
+  maxBuilderDispatches?: number;
+  /** Cap: max arbiter dispatches per task. Default 2. */
+  maxArbiterDispatches?: number;
+  /** Inject dispatchers + applier for tests. */
+  deps?: OrchestrateDeps;
+}
+
+export interface OrchestrateDeps {
+  dispatchBuilder: typeof dispatchBuilder;
+  dispatchColdReader: typeof dispatchColdReader;
+  dispatchArbiter: typeof dispatchArbiter;
+  applyAmendment: typeof applyAmendment;
+  /** Returns the SHA of the most recent commit on HEAD (for cold-reader diff range). */
+  resolveHeadSha: () => string;
+}
+
+export interface OrchestrateResult {
+  outcome: OrchestrateOutcome;
+  builderDispatches: number;
+  arbiterDispatches: number;
+  totalCostUsd: number;
+  state: OrchestratorState;
+  /** Last-known commit SHA produced by builder (when one exists). */
+  lastCommitSha?: string;
+  /** Reason text for halts (operator-readable). */
+  haltReason?: string;
+}
+
+const DEFAULT_DEPS: OrchestrateDeps = {
+  dispatchBuilder,
+  dispatchColdReader,
+  dispatchArbiter,
+  applyAmendment,
+  resolveHeadSha: () =>
+    execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim(),
+};
+
+export async function orchestrateTask(
+  opts: OrchestrateOptions
+): Promise<OrchestrateResult> {
+  const deps = opts.deps ?? DEFAULT_DEPS;
+  const statePath = opts.statePath ?? defaultStatePath(opts.cwd);
+  const maxCostUsd = opts.maxCostUsd ?? 5;
+  const maxBuilderDispatches = opts.maxBuilderDispatches ?? 3;
+  const maxArbiterDispatches = opts.maxArbiterDispatches ?? 2;
+
+  initState(opts.taskId, statePath);
+  appendEvent(statePath, {
+    task_id: opts.taskId,
+    type: 'orchestrate_start',
+    payload: {
+      caps: { maxCostUsd, maxBuilderDispatches, maxArbiterDispatches },
+    },
+  });
+
+  let builderDispatches = 0;
+  let arbiterDispatches = 0;
+  let totalCostUsd = 0;
+  let lastCommitSha: string | undefined;
+
+  function tally(cost: number): void {
+    totalCostUsd += cost;
+  }
+
+  function exceedsCost(): boolean {
+    return totalCostUsd >= maxCostUsd;
+  }
+
+  // Loop guard: each iteration is one builder dispatch + (possibly) follow-ups.
+  while (true) {
+    if (builderDispatches >= maxBuilderDispatches) {
+      return halt(
+        'halt_retry_cap',
+        `builder dispatch cap reached (${maxBuilderDispatches})`
+      );
+    }
+    if (exceedsCost()) {
+      return halt(
+        'halt_cost_cap',
+        `total cost cap reached ($${totalCostUsd.toFixed(2)} >= $${maxCostUsd})`
+      );
+    }
+
+    // ─── BUILDER ──────────────────────────────────────────────────────────
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'dispatch_start',
+      payload: { role: 'builder', attempt: builderDispatches + 1 },
+    });
+    const buildResult = await deps.dispatchBuilder({
+      taskId: opts.taskId,
+      taskListPath: opts.taskListPath,
+      cwd: opts.cwd,
+    });
+    builderDispatches += 1;
+    tally(buildResult.raw.costUsd);
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'dispatch_end',
+      payload: dispatchEndPayload('builder', buildResult),
+    });
+
+    if (!buildResult.exit) {
+      return halt(
+        'halt_verify_fail',
+        `builder parse_error: ${buildResult.parseError ?? 'unknown'}`
+      );
+    }
+
+    if (buildResult.exit.status === 'verify_fail') {
+      return halt('halt_verify_fail', 'builder reported verify_fail');
+    }
+    if (buildResult.exit.status === 'budget_exceeded') {
+      return halt('halt_budget_exceeded', 'builder hit per-dispatch budget');
+    }
+    if (buildResult.exit.status === 'spec_gap') {
+      // Skip cold-reader; go straight to arbiter.
+      const gap: SpecGapPayload = {
+        task_id: opts.taskId,
+        cited_section: buildResult.exit.cited_section ?? 'unknown',
+        gap_description: buildResult.exit.gap_description ?? '(no description)',
+        suggested_amendment: buildResult.exit.suggested_amendment,
+        files_inspected: buildResult.exit.files_inspected,
+      };
+      const arbResult = await runArbiterCycle(gap);
+      if (arbResult.outcome !== 'continue') return arbResult.result!;
+      continue;
+    }
+
+    // status === 'success'
+    lastCommitSha = buildResult.exit.commit_sha;
+    if (!lastCommitSha) {
+      return halt(
+        'halt_verify_fail',
+        'builder reported success but did not include commit_sha'
+      );
+    }
+
+    // ─── COLD-READER ──────────────────────────────────────────────────────
+    if (exceedsCost()) {
+      return halt(
+        'halt_cost_cap',
+        `total cost cap reached after build ($${totalCostUsd.toFixed(2)})`
+      );
+    }
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'dispatch_start',
+      payload: { role: 'cold-reader', attempt: 1, diff_sha: lastCommitSha },
+    });
+    const reviewResult = await deps.dispatchColdReader({
+      taskId: opts.taskId,
+      taskListPath: opts.taskListPath,
+      cwd: opts.cwd,
+      diffRange: `${lastCommitSha}~1..${lastCommitSha}`,
+    });
+    tally(reviewResult.raw.costUsd);
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'dispatch_end',
+      payload: dispatchEndPayload('cold-reader', reviewResult),
+    });
+
+    if (!reviewResult.exit) {
+      return halt(
+        'halt_verify_fail',
+        `cold-reader parse_error: ${reviewResult.parseError ?? 'unknown'}`
+      );
+    }
+    if (reviewResult.exit.verdict === 'approve') {
+      // 🎉 happy path
+      return success(
+        lastCommitSha,
+        builderDispatches,
+        arbiterDispatches,
+        totalCostUsd
+      );
+    }
+
+    // verdict === 'veto'
+    const blockingFinding = pickBlockingFinding(reviewResult.exit);
+    if (!blockingFinding) {
+      return halt(
+        'halt_verify_fail',
+        'cold-reader veto with no parseable finding to route on'
+      );
+    }
+    if (
+      blockingFinding.scope_check === 1 ||
+      blockingFinding.scope_check === 2
+    ) {
+      return halt(
+        'halt_builder_error_veto',
+        `cold-reader veto rooted in builder error (scope_check ${blockingFinding.scope_check}: ${blockingFinding.cited_section}). v1 does not auto-retry builder with veto context; human re-dispatches with context or amends task.`
+      );
+    }
+    // scope_check 3, 4, 5, 6 → arbiter
+    const gap: SpecGapPayload = {
+      task_id: opts.taskId,
+      cited_section: blockingFinding.cited_section,
+      gap_description: `Cold-reader veto (${blockingFinding.severity} #${blockingFinding.scope_check}, cite ${blockingFinding.cited_section}): ${blockingFinding.description}`,
+      suggested_amendment: undefined,
+      files_inspected: undefined,
+    };
+    const arbResult = await runArbiterCycle(gap);
+    if (arbResult.outcome !== 'continue') return arbResult.result!;
+    // continue → loop back to builder
+  }
+
+  // ─── helpers ───────────────────────────────────────────────────────────
+  async function runArbiterCycle(
+    gap: SpecGapPayload
+  ): Promise<{ outcome: 'continue' | 'halt'; result?: OrchestrateResult }> {
+    if (arbiterDispatches >= maxArbiterDispatches) {
+      return {
+        outcome: 'halt',
+        result: halt(
+          'halt_amendment_cap',
+          `arbiter dispatch cap reached (${maxArbiterDispatches})`
+        ),
+      };
+    }
+    if (exceedsCost()) {
+      return {
+        outcome: 'halt',
+        result: halt(
+          'halt_cost_cap',
+          `total cost cap reached before arbiter ($${totalCostUsd.toFixed(2)})`
+        ),
+      };
+    }
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'dispatch_start',
+      payload: { role: 'arbiter', attempt: arbiterDispatches + 1 },
+    });
+    const arbResult = await deps.dispatchArbiter({
+      specGap: gap,
+      taskListPath: opts.taskListPath,
+      cwd: opts.cwd,
+    });
+    arbiterDispatches += 1;
+    tally(arbResult.raw.costUsd);
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'dispatch_end',
+      payload: dispatchEndPayload('arbiter', arbResult),
+    });
+
+    if (!arbResult.exit) {
+      return {
+        outcome: 'halt',
+        result: halt(
+          'halt_verify_fail',
+          `arbiter parse_error: ${arbResult.parseError ?? 'unknown'}`
+        ),
+      };
+    }
+
+    if (arbResult.exit.verdict === 'pushback') {
+      return {
+        outcome: 'halt',
+        result: halt(
+          'halt_pushback_unsupported',
+          `arbiter pushback: "${arbResult.exit.pushback_clarification ?? '(no clarification)'}". v1 does not feed pushback into the builder input; human re-dispatches with context.`
+        ),
+      };
+    }
+
+    // amend_*  → apply, then continue (re-dispatch builder)
+    if (!arbResult.exit.amendment) {
+      return {
+        outcome: 'halt',
+        result: halt(
+          'halt_verify_fail',
+          'arbiter verdict was amend_* but no amendment payload present'
+        ),
+      };
+    }
+    const applyResult = deps.applyAmendment(arbResult.exit.amendment, {
+      repoRoot: opts.cwd,
+    });
+    if (!applyResult.ok) {
+      appendEvent(statePath, {
+        task_id: opts.taskId,
+        type: 'amendment_apply_failed',
+        payload: {
+          error: applyResult.error,
+          amendment: arbResult.exit.amendment,
+        },
+      });
+      return {
+        outcome: 'halt',
+        result: halt(
+          'halt_amendment_apply_failed',
+          `apply-amendment failed: ${applyResult.error}`
+        ),
+      };
+    }
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'amendment_applied',
+      payload: {
+        file: arbResult.exit.amendment.file,
+        anchor: arbResult.exit.amendment.anchor,
+        changelog_appended_at_eof: applyResult.changelog_appended_at_eof,
+      },
+    });
+    return { outcome: 'continue' };
+  }
+
+  function halt(
+    outcome: OrchestrateOutcome,
+    haltReason: string
+  ): OrchestrateResult {
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'cycle_halt',
+      payload: { reason: outcome, message: haltReason },
+    });
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'orchestrate_end',
+      payload: { outcome, totalCostUsd, builderDispatches, arbiterDispatches },
+    });
+    const state = loadState(statePath)!;
+    return {
+      outcome,
+      builderDispatches,
+      arbiterDispatches,
+      totalCostUsd,
+      state,
+      lastCommitSha,
+      haltReason,
+    };
+  }
+
+  function success(
+    commitSha: string,
+    bDispatches: number,
+    aDispatches: number,
+    cost: number
+  ): OrchestrateResult {
+    appendEvent(statePath, {
+      task_id: opts.taskId,
+      type: 'orchestrate_end',
+      payload: {
+        outcome: 'success',
+        commit_sha: commitSha,
+        totalCostUsd: cost,
+        builderDispatches: bDispatches,
+        arbiterDispatches: aDispatches,
+      },
+    });
+    const state = loadState(statePath)!;
+    return {
+      outcome: 'success',
+      builderDispatches: bDispatches,
+      arbiterDispatches: aDispatches,
+      totalCostUsd: cost,
+      state,
+      lastCommitSha: commitSha,
+    };
+  }
+}
+
+function pickBlockingFinding(exit: ColdReaderExit): ColdReaderFinding | null {
+  // Pick the highest-severity finding (CRITICAL > HIGH); ignore MEDIUM/LOW
+  // since they don't gate per the cold-reader contract.
+  const blocking = exit.findings.filter(
+    (f) => f.severity === 'CRITICAL' || f.severity === 'HIGH'
+  );
+  if (blocking.length === 0) return null;
+  blocking.sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
+  return blocking[0]!;
+}
+
+function severityRank(s: string): number {
+  return s === 'CRITICAL' ? 4 : s === 'HIGH' ? 3 : s === 'MEDIUM' ? 2 : 1;
+}
+
+function dispatchEndPayload(
+  role: 'builder' | 'cold-reader' | 'arbiter',
+  result:
+    | BuilderDispatchResult
+    | ColdReaderDispatchResult
+    | ArbiterDispatchResult
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    role,
+    cost_usd: result.raw.costUsd,
+    duration_ms: result.raw.durationMs,
+    num_turns: result.raw.numTurns,
+    session_id: result.raw.sessionId,
+    stop_reason: result.raw.stopReason,
+  };
+  if (result.parseError) base.parse_error = result.parseError;
+  if ('exit' in result && result.exit) {
+    if (role === 'builder') {
+      const e = result.exit as BuilderExit;
+      base.status = e.status;
+      if (e.status === 'success') base.commit_sha = e.commit_sha;
+    }
+    if (role === 'cold-reader') {
+      const e = result.exit as ColdReaderExit;
+      base.verdict = e.verdict;
+      base.findings_count = e.findings.length;
+    }
+    if (role === 'arbiter') {
+      const e = result.exit as ArbiterExit;
+      base.verdict = e.verdict;
+    }
+  }
+  return base;
+}
+
+export function summarizeOrchestrateResult(result: OrchestrateResult): string {
+  const summary = summarizeRun(result.state);
+  const lines = [
+    `outcome: ${result.outcome}`,
+    `cost: $${result.totalCostUsd.toFixed(4)}`,
+    `dispatches: builder=${result.builderDispatches}, arbiter=${result.arbiterDispatches}, total events=${result.state.events.length}`,
+    `amendments applied: ${summary.amendmentCount}`,
+  ];
+  if (result.lastCommitSha) {
+    lines.push(`last commit: ${result.lastCommitSha}`);
+  }
+  if (result.haltReason) {
+    lines.push(`halt reason: ${result.haltReason}`);
+  }
+  return lines.join('\n');
+}

--- a/scripts/harness/lib/state-store.test.ts
+++ b/scripts/harness/lib/state-store.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { appendEvent, initState, loadState, summarizeRun } from './state-store';
+
+let workDir: string;
+let statePath: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'harness-state-'));
+  statePath = join(workDir, '.harness/state.json');
+});
+
+afterEach();
+function afterEach() {
+  // No-op placeholder — vitest auto-cleans tmp via process exit.
+}
+
+describe('state-store', () => {
+  it('returns null when state file does not exist', () => {
+    expect(loadState(statePath)).toBeNull();
+  });
+
+  it('initState creates the file + returns the new state', () => {
+    const state = initState('T-14', statePath);
+    expect(state.run_id).toMatch(/^T-14-\d+$/);
+    expect(state.events).toEqual([]);
+    expect(existsSync(statePath)).toBe(true);
+    const reread = loadState(statePath);
+    expect(reread?.run_id).toBe(state.run_id);
+  });
+
+  it('appendEvent adds events with auto-timestamp', () => {
+    initState('T-14', statePath);
+    appendEvent(statePath, {
+      task_id: 'T-14',
+      type: 'dispatch_start',
+      payload: { role: 'builder' },
+    });
+    const s = loadState(statePath)!;
+    expect(s.events).toHaveLength(1);
+    expect(s.events[0]!.type).toBe('dispatch_start');
+    expect(s.events[0]!.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(s.events[0]!.payload.role).toBe('builder');
+  });
+
+  it('appendEvent on missing file creates state implicitly', () => {
+    appendEvent(statePath, {
+      task_id: 'T-14',
+      type: 'orchestrate_start',
+      payload: {},
+    });
+    expect(loadState(statePath)?.events).toHaveLength(1);
+  });
+
+  it('writes pretty JSON to disk', () => {
+    initState('T-14', statePath);
+    const raw = readFileSync(statePath, 'utf8');
+    expect(raw).toContain('\n');
+    expect(raw).toContain('  '); // 2-space indent
+  });
+
+  it('summarizeRun aggregates cost across dispatch_end events', () => {
+    initState('T-14', statePath);
+    appendEvent(statePath, {
+      task_id: 'T-14',
+      type: 'dispatch_end',
+      payload: { role: 'builder', cost_usd: 0.48, duration_ms: 128000 },
+    });
+    appendEvent(statePath, {
+      task_id: 'T-14',
+      type: 'dispatch_end',
+      payload: { role: 'cold-reader', cost_usd: 0.27, duration_ms: 41000 },
+    });
+    const summary = summarizeRun(loadState(statePath)!);
+    expect(summary.totalCostUsd).toBeCloseTo(0.75);
+    expect(summary.dispatchCount).toBe(2);
+    expect(summary.amendmentCount).toBe(0);
+    expect(summary.haltReason).toBeNull();
+  });
+
+  it('summarizeRun counts amendments + captures halt reason', () => {
+    initState('T-14', statePath);
+    appendEvent(statePath, {
+      task_id: 'T-14',
+      type: 'amendment_applied',
+      payload: { file: '02-design.md', anchor: '§D2' },
+    });
+    appendEvent(statePath, {
+      task_id: 'T-14',
+      type: 'cycle_halt',
+      payload: { reason: 'retry-cap-exceeded' },
+    });
+    const summary = summarizeRun(loadState(statePath)!);
+    expect(summary.amendmentCount).toBe(1);
+    expect(summary.haltReason).toBe('retry-cap-exceeded');
+  });
+
+  it('events preserve append order', () => {
+    initState('T-14', statePath);
+    for (const t of ['orchestrate_start', 'dispatch_start', 'dispatch_end']) {
+      appendEvent(statePath, {
+        task_id: 'T-14',
+        type: t as 'orchestrate_start',
+        payload: {},
+      });
+    }
+    const s = loadState(statePath)!;
+    expect(s.events.map((e) => e.type)).toEqual([
+      'orchestrate_start',
+      'dispatch_start',
+      'dispatch_end',
+    ]);
+  });
+
+  // Cleanup helper
+  it('cleanup', () => {
+    rmSync(workDir, { recursive: true, force: true });
+    expect(existsSync(workDir)).toBe(false);
+  });
+});

--- a/scripts/harness/lib/state-store.ts
+++ b/scripts/harness/lib/state-store.ts
@@ -1,0 +1,114 @@
+/**
+ * Append-only event log for orchestrator runs.
+ *
+ * State lives at `.harness/state.json` (gitignored). Each `appendEvent` writes
+ * a single line to the events array; the file is rewritten atomically. No
+ * resume-from-mid-cycle in v1 — the log is purely an audit trail for cost,
+ * duration, cycle counts, and per-task outcomes.
+ *
+ * Schema is intentionally narrow: any orchestrator-internal payload goes in
+ * `event.payload` as an opaque object. Callers structure their own payloads.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+export type StateEventType =
+  | 'orchestrate_start'
+  | 'orchestrate_end'
+  | 'dispatch_start'
+  | 'dispatch_end'
+  | 'amendment_applied'
+  | 'amendment_apply_failed'
+  | 'cycle_halt';
+
+export interface StateEvent {
+  ts: string; // ISO 8601
+  task_id: string;
+  type: StateEventType;
+  payload: Record<string, unknown>;
+}
+
+export interface OrchestratorState {
+  run_id: string;
+  started_at: string;
+  events: StateEvent[];
+}
+
+export function defaultStatePath(cwd?: string): string {
+  return resolve(cwd ?? process.cwd(), '.harness/state.json');
+}
+
+export function loadState(path: string): OrchestratorState | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, 'utf8');
+    return JSON.parse(raw) as OrchestratorState;
+  } catch {
+    return null;
+  }
+}
+
+export function initState(taskId: string, path: string): OrchestratorState {
+  const state: OrchestratorState = {
+    run_id: `${taskId}-${Date.now()}`,
+    started_at: new Date().toISOString(),
+    events: [],
+  };
+  writeStateAtomic(path, state);
+  return state;
+}
+
+export function appendEvent(
+  path: string,
+  event: Omit<StateEvent, 'ts'> & { ts?: string }
+): OrchestratorState {
+  const state = loadState(path) ?? {
+    run_id: `${event.task_id}-${Date.now()}`,
+    started_at: new Date().toISOString(),
+    events: [],
+  };
+  state.events.push({
+    ts: event.ts ?? new Date().toISOString(),
+    task_id: event.task_id,
+    type: event.type,
+    payload: event.payload,
+  });
+  writeStateAtomic(path, state);
+  return state;
+}
+
+export function summarizeRun(state: OrchestratorState): {
+  totalCostUsd: number;
+  dispatchCount: number;
+  amendmentCount: number;
+  haltReason: string | null;
+} {
+  let totalCostUsd = 0;
+  let dispatchCount = 0;
+  let amendmentCount = 0;
+  let haltReason: string | null = null;
+  for (const e of state.events) {
+    if (e.type === 'dispatch_end') {
+      dispatchCount += 1;
+      const cost = e.payload.cost_usd;
+      if (typeof cost === 'number') totalCostUsd += cost;
+    }
+    if (e.type === 'amendment_applied') amendmentCount += 1;
+    if (e.type === 'cycle_halt') {
+      const reason = e.payload.reason;
+      if (typeof reason === 'string') haltReason = reason;
+    }
+  }
+  return { totalCostUsd, dispatchCount, amendmentCount, haltReason };
+}
+
+function writeStateAtomic(path: string, state: OrchestratorState): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf8');
+  // node:fs renameSync is atomic on POSIX
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('node:fs').renameSync(tmp, path);
+}


### PR DESCRIPTION
## Summary

Adds the first orchestration loop. Replaces the manual sequence (operator runs `build`, then `review`, then `arbitrate-run`, then applies the amendment by hand, then re-runs `build`, then re-runs `review`) with a single `harness orchestrate T-N` command that chains all of them.

The full escalation cycle (round 31's empirical proof point) now runs automatically: build → review → veto → arbiter → apply → rebuild → re-review → success. Validated against 14 mocked-dispatcher tests; live e2e validation deferred to round 33 (T-14).

## What's new (3 modules + 30 unit tests + CLI command + README)

### `lib/state-store.ts` (+ 9 tests)
Append-only event log at `.harness/state.json`. Atomic writes via rename. Helpers: `initState`, `appendEvent`, `loadState`, `summarizeRun`. No resume-from-mid-cycle in v1; pure audit trail.

### `lib/dispatch/apply-amendment.ts` (+ 7 tests)
Takes `ArbiterAmendment` and applies deterministically:
- Locate `before` (must match exactly once — refuses zero-match, multi-match, and pure-addition cases)
- Replace with `after`
- Append `changelog_entry` to the file's changelog block (§10 / §D11 / §T0 routed by filename)
- Falls back to EOF append with a marker if changelog block is missing

### `lib/orchestrate.ts` (+ 14 tests)
The loop, with explicit halt policies for each failure mode. All dispatchers + applier injected via `OrchestrateDeps` so tests run at $0 cost.

**Routing:**
- Build success → cold-reader → approve = done
- Cold-reader veto on `scope_check` 1, 2 (builder error: BR not implemented, AC not asserted) → **halt for human**. v1 doesn't auto-retry builder with veto context (would require extending `dispatchBuilder` to accept extra context — out of v1 scope).
- Cold-reader veto on `scope_check` 3, 4, 5, 6 (spec/design ambiguity) → arbiter → apply amendment → re-build → re-review.
- Build `spec_gap` → arbiter directly (skip cold-reader).
- Arbiter `pushback` → halt for human (same context-passing limit as scope-1/2).
- Apply-amendment failure (before doesn't match exactly) → halt for human.

**Caps:** 2 builder retries (3 total), 2 arbiter dispatches, $5 / 30 min. Halts for human on cap.

### CLI: `harness orchestrate T-N`
Wraps `orchestrateTask`. Prints summary (cost, dispatches, last commit, halt reason) or `--json`. Exits 0 on success, 2 on any halt.

## Test coverage (all paths exercised with mocks)

| Path | Test |
|------|------|
| Happy path | `build success → review approve` |
| Full escalation | `build success → review veto scope 4 → arbiter amend_design → apply → re-build → re-review approve` |
| Builder-error veto halts | `scope 1 + scope 2 cases` |
| `spec_gap` → arbiter direct | `skips cold-reader, goes to arbiter` |
| Arbiter pushback halts | `halt_pushback_unsupported with clarification surfaced` |
| Amendment apply failure | `halt_amendment_apply_failed with error surfaced` |
| Builder cap | `halt_retry_cap when builder dispatched maxBuilderDispatches times` |
| Arbiter cap | `halt_amendment_cap when arbiter dispatched max times` |
| Cost cap | `halt_cost_cap before next dispatch` |
| `verify_fail` | halt immediately |
| Parse error | halt as verify_fail with parse_error in haltReason |
| state.json correctness | events ordered + amendment_applied recorded |

30 unit tests across the 3 modules. All pass.

## Verify

- `pnpm preflight`: clean (lint + knip + build + test:coverage)
- `pnpm exec vitest run scripts/harness/lib/orchestrate.test.ts`: 14/14 PASS
- `pnpm exec vitest run scripts/harness/lib/state-store.test.ts`: 9/9 PASS
- `pnpm exec vitest run scripts/harness/lib/dispatch/apply-amendment.test.ts`: 7/7 PASS

## Live e2e (NOT in this PR)

Round 33 will dispatch T-14 (EmergencyActivationFab) through `harness orchestrate T-14` end-to-end. Predictions:
- Cost lands ~$0.75 if happy-path
- Cost lands ~$3.50 if escalation triggers
- Halts for human on scope-1/2 veto OR arbiter pushback if either fires

If T-14 lands cleanly, T-15 runs the same way. Slice 1 ships fully harness-driven through T-16 (manual smoke gate).

## Test plan

- [ ] CI green
- [ ] Reviewer reads `lib/orchestrate.ts` for the routing decisions (the v1 limits on scope-1/2 + pushback are explicit and worth eyeballing)
- [ ] Reviewer confirms `applyAmendment` refuses ambiguous matches — that's the load-bearing safety