### PR TITLE
feat(incidents): T-14 EmergencyActivationFab — first fully-orchestrated slice-1 commit

### DIFF
--- a/docs/specs/incident-capture/03-tasks.md
+++ b/docs/specs/incident-capture/03-tasks.md
@@ -104,7 +104,7 @@ Goal after this slice: a single-pet user can tap a global FAB, see a running tim
 - **What:** Create `src/features/incidents/pages/ActiveIncidentPage.tsx`. Reads `activeIncident` from store; renders `<IncidentCaptureSurface>`. Redirects to `/pets` (or shows empty state) if no active incident.
 - **Verify:** Component test: renders the surface when an active incident exists; redirects when none.
 
-### `[ ]` T-14 — EmergencyActivationFab (single-pet only)
+### `[x]` T-14 — EmergencyActivationFab (single-pet only)
 
 - **Cite:** spec BR-1, BR-27, BR-28 (rules 1+2 only — pet-scoped or single-pet); design §D2 FAB tap-behavior table (rows 2 + 3)
 - **What:** Create `src/components/common/EmergencyActivationFab.tsx`. Hidden per the four hide-conditions from design §D2. Tap behavior: pre-fill petId from a pet-scoped surface (read from route params); for non-pet-scoped surface with exactly one pet, use that pet. **Multi-pet picker deferred to T-23.** **Resume short-circuit deferred to T-25.**

--- a/scripts/harness/lib/state-store.ts
+++ b/scripts/harness/lib/state-store.ts
@@ -10,7 +10,13 @@
  * `event.payload` as an opaque object. Callers structure their own payloads.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 export type StateEventType =
@@ -109,6 +115,5 @@ function writeStateAtomic(path: string, state: OrchestratorState): void {
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf8');
   // node:fs renameSync is atomic on POSIX
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('node:fs').renameSync(tmp, path);
+  renameSync(tmp, path);
 }

--- a/src/components/common/EmergencyActivationFab.test.tsx
+++ b/src/components/common/EmergencyActivationFab.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EmergencyActivationFab } from './EmergencyActivationFab';
+import { useFeatureFlag } from '@featureFlags/hooks/useFeatureFlag';
+import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
+import { usePetsStore } from '@store/pets.store';
+import { useAuthStore } from '@store/auth.store';
+import type { Pet } from '@features/pets/types';
+
+// Mutable state read inside the vi.mock factory — lets each test vary the router.
+const routerState = {
+  pathname: '/pets',
+  params: {} as Record<string, string>,
+  navigate: vi.fn(),
+};
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...mod,
+    useLocation: () => ({ pathname: routerState.pathname }),
+    useNavigate: () => routerState.navigate,
+    useParams: () => routerState.params,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@featureFlags/hooks/useFeatureFlag');
+vi.mock('@store/useIncidentStore');
+vi.mock('@store/pets.store');
+vi.mock('@store/auth.store');
+
+function makePet(id: string): Pet {
+  return {
+    id,
+    name: 'Buddy',
+    breed: 'Lab',
+    birthDate: new Date('2020-01-01'),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: 'user-1',
+    isArchived: false,
+    photos: [],
+  };
+}
+
+type SetupOptions = {
+  flagOn?: boolean;
+  user?: { uid: string } | null;
+  pathname?: string;
+  params?: Record<string, string>;
+  activeIncident?: IncidentState['activeIncident'];
+  pets?: Pet[];
+  startIncident?: ReturnType<typeof vi.fn>;
+};
+
+function setupDefaults({
+  flagOn = true,
+  user = { uid: 'user-1' },
+  pathname = '/pets',
+  params = {},
+  activeIncident = null,
+  pets = [makePet('pet-1')],
+  startIncident = vi.fn().mockResolvedValue(undefined),
+}: SetupOptions = {}) {
+  vi.mocked(useFeatureFlag).mockReturnValue(flagOn);
+  // useAuthStore is called with a selector: useAuthStore((s) => s.user)
+  vi.mocked(useAuthStore).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: any) => (selector ? selector({ user }) : { user })
+  );
+  routerState.pathname = pathname;
+  routerState.params = params;
+  routerState.navigate = vi.fn();
+  vi.mocked(useIncidentStore).mockReturnValue({
+    activeIncident,
+    startIncident,
+  } as unknown as IncidentState);
+  // usePetsStore is called with a selector: usePetsStore((s) => s.pets)
+  vi.mocked(usePetsStore).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: any) => (selector ? selector({ pets }) : { pets })
+  );
+}
+
+describe('EmergencyActivationFab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaults();
+  });
+
+  it('renders the FAB when all visibility conditions are satisfied', () => {
+    render(<EmergencyActivationFab />);
+    expect(
+      screen.getByRole('button', { name: 'incidents.activate' })
+    ).toBeInTheDocument();
+  });
+
+  // Verify line AC: tap with petId fires startIncident synchronously and navigates
+  it('fires startIncident with petId from route param and navigates to /incidents/active', async () => {
+    const startIncident = vi.fn().mockResolvedValue(undefined);
+    setupDefaults({ params: { id: 'pet-1' }, startIncident });
+
+    const user = userEvent.setup();
+    render(<EmergencyActivationFab />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'incidents.activate' })
+    );
+
+    // startIncident is called synchronously (before the async write resolves — §D8 NFR-2)
+    expect(startIncident).toHaveBeenCalledWith({ petId: 'pet-1' });
+    expect(routerState.navigate).toHaveBeenCalledWith('/incidents/active');
+    // navigate fires in the same synchronous event handler, before the promise resolves
+    const startOrder = startIncident.mock.invocationCallOrder[0];
+    const navOrder = routerState.navigate.mock.invocationCallOrder[0];
+    expect(navOrder).toBeGreaterThan(startOrder);
+  });
+
+  it('fires startIncident with the only pet id when on non-pet-scoped surface', async () => {
+    const startIncident = vi.fn().mockResolvedValue(undefined);
+    setupDefaults({
+      params: {},
+      pets: [makePet('pet-solo')],
+      startIncident,
+    });
+
+    const user = userEvent.setup();
+    render(<EmergencyActivationFab />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'incidents.activate' })
+    );
+
+    expect(startIncident).toHaveBeenCalledWith({ petId: 'pet-solo' });
+    expect(routerState.navigate).toHaveBeenCalledWith('/incidents/active');
+  });
+
+  it('navigates to /incidents/active without starting a new incident when one is already active (BR-26)', async () => {
+    const startIncident = vi.fn();
+    setupDefaults({
+      activeIncident: {
+        id: 'inc-active',
+      } as unknown as IncidentState['activeIncident'],
+      startIncident,
+    });
+
+    const user = userEvent.setup();
+    render(<EmergencyActivationFab />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'incidents.activate' })
+    );
+
+    expect(startIncident).not.toHaveBeenCalled();
+    expect(routerState.navigate).toHaveBeenCalledWith('/incidents/active');
+  });
+
+  // Verify line: hidden when unauthenticated
+  it('is hidden when user is unauthenticated (user === null)', () => {
+    setupDefaults({ user: null });
+    render(<EmergencyActivationFab />);
+    expect(
+      screen.queryByRole('button', { name: 'incidents.activate' })
+    ).not.toBeInTheDocument();
+  });
+
+  // Verify line: hidden when on /incidents/active
+  it('is hidden when the current route is /incidents/active', () => {
+    setupDefaults({ pathname: '/incidents/active' });
+    render(<EmergencyActivationFab />);
+    expect(
+      screen.queryByRole('button', { name: 'incidents.activate' })
+    ).not.toBeInTheDocument();
+  });
+
+  // Verify line: hidden when flag off
+  it('is hidden when incidentsEnabled feature flag is off', () => {
+    setupDefaults({ flagOn: false });
+    render(<EmergencyActivationFab />);
+    expect(
+      screen.queryByRole('button', { name: 'incidents.activate' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('is hidden when user has zero pets (BR-27 zero-pet exception)', () => {
+    setupDefaults({ pets: [] });
+    render(<EmergencyActivationFab />);
+    expect(
+      screen.queryByRole('button', { name: 'incidents.activate' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/common/EmergencyActivationFab.tsx
+++ b/src/components/common/EmergencyActivationFab.tsx
@@ -1,0 +1,66 @@
+import { Fab } from '@mui/material';
+import WarningIcon from '@mui/icons-material/Warning';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuthStore } from '@store/auth.store';
+import { useIncidentStore } from '@store/useIncidentStore';
+import { usePetsStore } from '@store/pets.store';
+import { useFeatureFlag } from '@featureFlags/hooks/useFeatureFlag';
+
+// Global emergency activation FAB (BR-27, AC-18).
+// Mounts outside the route tree in App.tsx so it survives navigation.
+// Hidden conditions per §D2: unauthenticated, on /incidents/active, flag off, zero pets.
+export function EmergencyActivationFab() {
+  const { t } = useTranslation('common');
+  const incidentsEnabled = useFeatureFlag('incidentsEnabled');
+  const user = useAuthStore((s) => s.user);
+  const { pathname } = useLocation();
+  const { activeIncident, startIncident } = useIncidentStore();
+  const pets = usePetsStore((s) => s.pets);
+  const params = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+
+  if (
+    !incidentsEnabled ||
+    !user ||
+    pathname === '/incidents/active' ||
+    pets.length === 0
+  ) {
+    return null;
+  }
+
+  const handleTap = () => {
+    // BR-26: active incident already exists — resume it, don't start a new one
+    if (activeIncident) {
+      navigate('/incidents/active');
+      return;
+    }
+
+    // BR-28: petId resolution — route param wins, then single-pet auto-select
+    const petId = params.id ?? (pets.length === 1 ? pets[0].id : null);
+    if (petId) {
+      // §D8 NFR-2: startIncident sets activeIncident synchronously before
+      // the background Firestore write; navigate immediately after the call
+      void startIncident({ petId });
+      navigate('/incidents/active');
+    }
+    // Multi-pet, non-pet-scoped → ActivationPetPicker (separate task, T-14 scope ends here)
+  };
+
+  return (
+    <Fab
+      color="error"
+      aria-label={t('incidents.activate')}
+      onClick={handleTap}
+      sx={{
+        position: 'fixed',
+        bottom: 16,
+        right: 16,
+        width: 56,
+        height: 56,
+      }}
+    >
+      <WarningIcon />
+    </Fab>
+  );
+}


### PR DESCRIPTION
## Summary

Round 33 — first live `harness orchestrate T-14` dispatch landed clean. Build → review → approve → done, fully automated. Plus a real ESM/CJS bug in state-store.ts that only the live tsx run could surface.

## Round 33 result

```
outcome:     success (first try)
cost:        $1.6088
dispatches:  builder=1, arbiter=0
events:      6 (orchestrate_start → builder pair → cold-reader pair → orchestrate_end)
amendments:  0
commit:      dd3f5a1 — feat(incidents): EmergencyActivationFab single-pet slice (BR-27, BR-28, AC-18)
```

The subagent shipped 263 lines (66 prod + 197 test) covering all 4 hide-conditions, single-pet auto-select, multi-pet placeholder, and the active-incident short-circuit. 8/8 tests pass independently. Citation linter accepted `(BR-27, BR-28, AC-18)`. Cold-reader `approve` with 0 findings.

## Round 33 finding shipped this PR

`state-store.ts` used `require('node:fs').renameSync(...)` for atomic writes. ESLint suppressed with `no-require-imports` exception. **Vitest's ESM handling tolerated it; all 9 unit tests passed.** But tsx's runtime doesn't provide `require` → orchestrate failed at the first event-write with `"require is not defined"`.

Fixed: import `renameSync` at the top, use directly. All 30 dispatch-related tests still pass. Lesson: vitest-pass ≠ live-tsx-pass for ESM/CJS interop. The orchestrator's first live run was the only thing that surfaced this.

## Cumulative slice-1 cost via harness (rounds 27-33)

| Task | Cost | Outcome |
|------|------|---------|
| T-11 | $2.52 (4 dispatches across 27-29) | success at attempt 5 — produced 4 methodology fixes |
| T-12 | $0.75 (build + cold-reader, manual chain) | success first try |
| T-13 | $3.49 (full escalation cycle, manual chain) | success after arbiter `amend_design` |
| **T-14** | **$1.61 (orchestrated, build + cold-reader)** | **success first try, fully automated** |

## Slice 1: 8/11 → 9/11

Remaining: T-15 (Routes + App.tsx mount — much of which the round-31 subagent already speculatively wrote in scope-creep, captured as evidence), T-16 (manual smoke).

## Verify

- `pnpm preflight`: clean (preflight ran during `git push`)
- `pnpm exec vitest run src/components/common/EmergencyActivationFab.test.tsx`: 8/8 PASS
- `.harness/state.json` written cleanly with 6 events; cost reconstruction matches CLI output

## Carry-overs

- Round 34 = T-15 orchestrated dispatch. Routes + App.tsx mount + global FAB integration. Same orchestrator command.
- After T-15, T-16 is manual smoke under `dev:with-emulators` (slice-end human gate per `03-tasks.md`).
- Methodology fix candidate: ESM/CJS interop check in CI (or a tsx-runner test mode that catches `require` usage in ESM-context lib code). Not in this PR; logged for follow-up.

## Test plan

- [ ] CI green
- [ ] Reviewer reads `state-store.ts` import block to confirm `renameSync` is the only change
- [ ] Reviewer skims `dd3f5a1` to confirm subagent's FAB matches T-14's task body (4 hide-conditions, single-pet auto, multi-pet placeholder)