### PR TITLE
feat(incidents): T-15 routes + cold-reader JSON-only + orchestrator raw-text capture (slice 1: 10/11)

### DIFF
--- a/docs/specs/incident-capture/03-tasks.md
+++ b/docs/specs/incident-capture/03-tasks.md
@@ -110,7 +110,7 @@ Goal after this slice: a single-pet user can tap a global FAB, see a running tim
 - **What:** Create `src/components/common/EmergencyActivationFab.tsx`. Hidden per the four hide-conditions from design §D2. Tap behavior: pre-fill petId from a pet-scoped surface (read from route params); for non-pet-scoped surface with exactly one pet, use that pet. **Multi-pet picker deferred to T-23.** **Resume short-circuit deferred to T-25.**
 - **Verify:** Component test: tap with petId fires `startIncident` synchronously and navigates to `/incidents/active`. Hidden when unauthenticated, when on `/incidents/active`, when flag off.
 
-### `[ ]` T-15 — Routes + App.tsx mount
+### `[x]` T-15 — Routes + App.tsx mount
 
 - **Cite:** spec BR-27 (global FAB); design §D2 routes
 - **What:** Add `/incidents/active` route to `AppRoutes.tsx` (flag-gated). Mount `<EmergencyActivationFab>` in `src/App.tsx` outside the route tree.

--- a/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
+++ b/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
@@ -104,8 +104,14 @@ elevate it to a finding.
 
 ## Output format
 
-Emit JSON. The harness parses this directly to gate merge and produce the PR
-comment thread.
+**Emit a single JSON object inside a fenced ` ```json ` block. NO prose
+before or after the fence.** No prelude like "Verdict: approve". No
+follow-up explanation outside the JSON. The harness's parser looks for
+a fenced JSON block with a `verdict` field; anything else fails with
+`invalid verdict (got undefined)` and the orchestrator halts.
+
+The JSON's `notes` field is the only place for out-of-scope prose
+observations — use it freely, but keep it inside the JSON.
 
 ```json
 {
@@ -124,6 +130,8 @@ comment thread.
   "notes": "<optional — out-of-scope concerns the human might want to see>"
 }
 ```
+
+**Methodology basis:** round-34 cold-reader emitted `**Verdict: \`approve\` — no findings.**` as bold-prose preamble before the JSON-shaped notes; parser found no `verdict` field; orchestrator halted at $0.55 for a clean approve. JSON-fenced-only is the operationally correct format because it's what the parser is built for.
 
 **`cited_section` MUST be one of: `BR-N`, `NFR-N`, `AC-N`, `US-N`, `OQ-N`,
 `DQ-N`, `§N`, `§DN`.** No other values are valid. Findings rooted in the

--- a/scripts/harness/lib/orchestrate.ts
+++ b/scripts/harness/lib/orchestrate.ts
@@ -468,7 +468,14 @@ function dispatchEndPayload(
     session_id: result.raw.sessionId,
     stop_reason: result.raw.stopReason,
   };
-  if (result.parseError) base.parse_error = result.parseError;
+  if (result.parseError) {
+    base.parse_error = result.parseError;
+    // Preserve raw text on parse failure so debugging doesn't require a
+    // re-dispatch (round-34 finding: orchestrator halted on cold-reader
+    // parse error but raw text was lost; manual re-dispatch was needed
+    // to see the actual response).
+    base.raw_result_text = result.raw.resultText;
+  }
   if ('exit' in result && result.exit) {
     if (role === 'builder') {
       const e = result.exit as BuilderExit;

--- a/scripts/harness/lib/prompts/cold-reader-code.md
+++ b/scripts/harness/lib/prompts/cold-reader-code.md
@@ -104,8 +104,14 @@ elevate it to a finding.
 
 ## Output format
 
-Emit JSON. The harness parses this directly to gate merge and produce the PR
-comment thread.
+**Emit a single JSON object inside a fenced ` ```json ` block. NO prose
+before or after the fence.** No prelude like "Verdict: approve". No
+follow-up explanation outside the JSON. The harness's parser looks for
+a fenced JSON block with a `verdict` field; anything else fails with
+`invalid verdict (got undefined)` and the orchestrator halts.
+
+The JSON's `notes` field is the only place for out-of-scope prose
+observations — use it freely, but keep it inside the JSON.
 
 ```json
 {
@@ -124,6 +130,8 @@ comment thread.
   "notes": "<optional — out-of-scope concerns the human might want to see>"
 }
 ```
+
+**Methodology basis:** round-34 cold-reader emitted `**Verdict: \`approve\` — no findings.\*\*`as bold-prose preamble before the JSON-shaped notes; parser found no`verdict` field; orchestrator halted at $0.55 for a clean approve. JSON-fenced-only is the operationally correct format because it's what the parser is built for.
 
 **`cited_section` MUST be one of: `BR-N`, `NFR-N`, `AC-N`, `US-N`, `OQ-N`,
 `DQ-N`, `§N`, `§DN`.** No other values are valid. Findings rooted in the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { ErrorIndicator } from '@components/common/ErrorIndicator/ErrorIndicator
 import { RoutePrefetcher } from '@features/pets/RoutePrefetcher';
 import { NavigationBar } from '@components/common/NavigationBar/NavigationBar';
 import { FeatureFlagsDevTool } from '@featureFlags/components/FeatureFlagsDevTool';
+import { EmergencyActivationFab } from '@components/common/EmergencyActivationFab';
 
 import './App.css';
 import { AppRoutes } from './AppRoutes';
@@ -30,6 +31,7 @@ const App = () => {
       {isLoading && <LoadingIndicator />}
       {hasError && <ErrorIndicator text={errorText} />}
       <AppRoutes />
+      <EmergencyActivationFab />
       {import.meta.env.DEV && <FeatureFlagsDevTool />}
     </div>
   );

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -28,6 +28,14 @@ const EditVetPage = lazy(
   () => import('@features/veterinarians/pages/EditVetPage')
 );
 
+// Incidents feature pages (slice 1)
+const ActiveIncidentPage = lazy(
+  () => import('@features/incidents/pages/ActiveIncidentPage')
+);
+const SavedIncidentPage = lazy(
+  () => import('@features/incidents/pages/SavedIncidentPage')
+);
+
 export function AppRoutes() {
   const enablePetList = useFeatureFlag('petListEnabled');
   const enableAddPet = useFeatureFlag('addPetEnabled');
@@ -36,6 +44,7 @@ export function AppRoutes() {
   const { initializing } = useAuthStore();
   const isAuthenticated = useIsAuthenticated();
   const enableVets = useFeatureFlag('vetsEnabled');
+  const incidentsEnabled = useFeatureFlag('incidentsEnabled');
 
   if (initializing) {
     return <LoadingIndicator />;
@@ -124,6 +133,27 @@ export function AppRoutes() {
           element={
             enableVets ? (
               <EditVetPage />
+            ) : (
+              <Navigate to="/feature-unavailable" replace />
+            )
+          }
+        />
+        {/* Incidents routes (flag-gated, BR-27) */}
+        <Route
+          path="/incidents/active"
+          element={
+            incidentsEnabled ? (
+              <ActiveIncidentPage />
+            ) : (
+              <Navigate to="/feature-unavailable" replace />
+            )
+          }
+        />
+        <Route
+          path="/pets/:petId/incidents/:incidentId"
+          element={
+            incidentsEnabled ? (
+              <SavedIncidentPage />
             ) : (
               <Navigate to="/feature-unavailable" replace />
             )

--- a/src/features/incidents/hooks/useSavedIncident.test.ts
+++ b/src/features/incidents/hooks/useSavedIncident.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSavedIncident } from './useSavedIncident';
+import { useAuthStore } from '@store/auth.store';
+import { incidentService } from '@services/incidentService';
+import type { Incident } from '@features/incidents/types';
+
+vi.mock('@store/auth.store');
+
+vi.mock('@services/incidentService', () => ({
+  incidentService: {
+    getIncident: vi.fn(),
+  },
+}));
+
+function makeIncident(overrides: Partial<Incident> = {}): Incident {
+  const now = new Date('2026-05-02T10:00:00.000Z');
+  return {
+    id: 'inc-1',
+    userId: 'user-1',
+    createdBy: 'user-1',
+    petId: 'pet-1',
+    startedAt: now,
+    endedAt: new Date('2026-05-02T10:05:00.000Z'),
+    type: null,
+    severity: null,
+    chips: [],
+    journal: [],
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('useSavedIncident', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useAuthStore).mockImplementation((selector: any) =>
+      selector?.({ user: { uid: 'user-1' } })
+    );
+  });
+
+  it('returns undefined (loading) initially', () => {
+    vi.mocked(incidentService.getIncident).mockReturnValue(
+      new Promise(() => {})
+    );
+    const { result } = renderHook(() => useSavedIncident('inc-1'));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the incident when found', async () => {
+    const incident = makeIncident();
+    vi.mocked(incidentService.getIncident).mockResolvedValue(incident);
+    const { result } = renderHook(() => useSavedIncident('inc-1'));
+    await waitFor(() => expect(result.current).not.toBeUndefined());
+    expect(result.current).toEqual(incident);
+  });
+
+  it('returns null when service returns null', async () => {
+    vi.mocked(incidentService.getIncident).mockResolvedValue(null);
+    const { result } = renderHook(() => useSavedIncident('inc-1'));
+    await waitFor(() => expect(result.current).not.toBeUndefined());
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when service throws', async () => {
+    vi.mocked(incidentService.getIncident).mockRejectedValue(
+      new Error('network error')
+    );
+    const { result } = renderHook(() => useSavedIncident('inc-1'));
+    await waitFor(() => expect(result.current).not.toBeUndefined());
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null immediately when incidentId is undefined', () => {
+    const { result } = renderHook(() => useSavedIncident(undefined));
+    expect(result.current).toBeNull();
+    expect(vi.mocked(incidentService.getIncident)).not.toHaveBeenCalled();
+  });
+
+  it('returns null immediately when user is not authenticated', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useAuthStore).mockImplementation((selector: any) =>
+      selector?.({ user: null })
+    );
+    const { result } = renderHook(() => useSavedIncident('inc-1'));
+    expect(result.current).toBeNull();
+    expect(vi.mocked(incidentService.getIncident)).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/incidents/hooks/useSavedIncident.ts
+++ b/src/features/incidents/hooks/useSavedIncident.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import { incidentService } from '@services/incidentService';
+import { useAuthStore } from '@store/auth.store';
+import type { Incident } from '@features/incidents/types';
+
+// Loads a single saved incident by id for SavedIncidentPage (§D2, BR-23, BR-25).
+// Returns undefined while loading, null when not found, or the Incident when found.
+export function useSavedIncident(
+  incidentId: string | undefined
+): Incident | null | undefined {
+  const userId = useAuthStore((s) => s.user?.uid);
+  const [incident, setIncident] = useState<Incident | null | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    if (!userId || !incidentId) {
+      setIncident(null);
+      return;
+    }
+    incidentService
+      .getIncident(userId, incidentId)
+      .then(setIncident)
+      .catch(() => setIncident(null));
+  }, [userId, incidentId]);
+
+  return incident;
+}

--- a/src/features/incidents/pages/SavedIncidentPage.test.tsx
+++ b/src/features/incidents/pages/SavedIncidentPage.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SavedIncidentPage from './SavedIncidentPage';
+import { useSavedIncident } from '../hooks/useSavedIncident';
+import { Navigate } from 'react-router-dom';
+import type { Incident } from '@features/incidents/types';
+
+vi.mock('react-router-dom', () => ({
+  Navigate: vi.fn(() => null),
+  useParams: vi.fn(() => ({ petId: 'pet-1', incidentId: 'inc-1' })),
+}));
+
+vi.mock('../hooks/useSavedIncident');
+
+vi.mock('../components/IncidentCaptureSurface', () => ({
+  IncidentCaptureSurface: ({ incident }: { incident: Incident }) => (
+    <div
+      data-testid="incident-capture-surface"
+      data-incident-id={incident.id}
+    />
+  ),
+}));
+
+vi.mock('@components/common/LoadingIndicator/LoadingIndicator', () => ({
+  LoadingIndicator: () => <div data-testid="loading-indicator" />,
+}));
+
+function makeIncident(overrides: Partial<Incident> = {}): Incident {
+  const now = new Date('2026-05-02T10:00:00.000Z');
+  return {
+    id: 'inc-1',
+    userId: 'user-1',
+    createdBy: 'user-1',
+    petId: 'pet-1',
+    startedAt: now,
+    endedAt: new Date('2026-05-02T10:05:00.000Z'),
+    type: null,
+    severity: null,
+    chips: [],
+    journal: [],
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('SavedIncidentPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading indicator while hook returns undefined', () => {
+    vi.mocked(useSavedIncident).mockReturnValue(undefined);
+    render(<SavedIncidentPage />);
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
+  it('renders IncidentCaptureSurface when incident is found', () => {
+    vi.mocked(useSavedIncident).mockReturnValue(makeIncident());
+    render(<SavedIncidentPage />);
+    const surface = screen.getByTestId('incident-capture-surface');
+    expect(surface).toBeInTheDocument();
+    expect(surface).toHaveAttribute('data-incident-id', 'inc-1');
+  });
+
+  it('redirects to /pets when incident is not found', () => {
+    vi.mocked(useSavedIncident).mockReturnValue(null);
+    render(<SavedIncidentPage />);
+    expect(vi.mocked(Navigate)).toHaveBeenCalledWith(
+      expect.objectContaining({ to: '/pets', replace: true }),
+      undefined
+    );
+    expect(
+      screen.queryByTestId('incident-capture-surface')
+    ).not.toBeInTheDocument();
+  });
+
+  it('redirects to /pets when incident petId does not match route petId', () => {
+    vi.mocked(useSavedIncident).mockReturnValue(
+      makeIncident({ petId: 'pet-other' })
+    );
+    render(<SavedIncidentPage />);
+    expect(vi.mocked(Navigate)).toHaveBeenCalledWith(
+      expect.objectContaining({ to: '/pets', replace: true }),
+      undefined
+    );
+  });
+});

--- a/src/features/incidents/pages/SavedIncidentPage.tsx
+++ b/src/features/incidents/pages/SavedIncidentPage.tsx
@@ -1,0 +1,24 @@
+import { Navigate, useParams } from 'react-router-dom';
+import { useSavedIncident } from '../hooks/useSavedIncident';
+import { IncidentCaptureSurface } from '../components/IncidentCaptureSurface';
+import { LoadingIndicator } from '@components/common/LoadingIndicator/LoadingIndicator';
+
+// /pets/:petId/incidents/:incidentId route (§D2, BR-23, BR-25).
+// Redirects to /pets if incident is not found or petId doesn't match.
+export default function SavedIncidentPage() {
+  const { petId, incidentId } = useParams<{
+    petId: string;
+    incidentId: string;
+  }>();
+  const incident = useSavedIncident(incidentId);
+
+  if (incident === undefined) {
+    return <LoadingIndicator />;
+  }
+
+  if (!incident || incident.petId !== petId) {
+    return <Navigate to="/pets" replace />;
+  }
+
+  return <IncidentCaptureSurface incident={incident} />;
+}

--- a/src/services/incidentService.test.ts
+++ b/src/services/incidentService.test.ts
@@ -120,3 +120,29 @@ describe('incidentService.findActiveIncident', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('incidentService.getIncident', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes through to repository.getById and returns the incident', async () => {
+    const startedAt = new Date('2026-05-02T10:00:00.000Z');
+    mockGetById.mockResolvedValue({
+      id: 'incident-2',
+      userId,
+      petId: 'pet-1',
+      startedAt,
+      endedAt: null,
+    });
+    const result = await incidentService.getIncident(userId, 'incident-2');
+    expect(mockGetById).toHaveBeenCalledWith('incident-2');
+    expect(result).toMatchObject({ id: 'incident-2' });
+  });
+
+  it('returns null when the repository finds no incident', async () => {
+    mockGetById.mockResolvedValue(null);
+    const result = await incidentService.getIncident(userId, 'missing');
+    expect(result).toBeNull();
+  });
+});

--- a/src/services/incidentService.ts
+++ b/src/services/incidentService.ts
@@ -44,6 +44,14 @@ export class IncidentService {
     const repo = new IncidentRepository(userId);
     return repo.findActiveForUser();
   }
+
+  async getIncident(
+    userId: string,
+    incidentId: string
+  ): Promise<Incident | null> {
+    const repo = new IncidentRepository(userId);
+    return repo.getById(incidentId);
+  }
 }
 
 export const incidentService = new IncidentService();


### PR DESCRIPTION
## Summary

Round 34 — second fully-orchestrated slice-1 task. Builder shipped clean (T-15 routes + App.tsx mount, commit `c9f6067`), but the cold-reader emitted prose preamble before its JSON, parser couldn't find `verdict`, orchestrator halted. Two fixes shipped + 2 carry-overs logged + a coverage gap surfaced by preflight.

## Round 34 trajectory

| # | Action | Cost | Result |
|---|--------|------|--------|
| 1 | T-15 build (orchestrated) | $1.25 | success, commit `c9f6067` |
| 2 | T-15 cold-read (orchestrated) | $0.48 | parse_failed → orchestrator halt |
| 3 | T-15 cold-read (manual `--json`, post-prompt-fix) | $0.55 | parse_failed STILL (model non-determinism) |
| 4 | T-15 cold-read (manual `--json`, retry) | $0.31 | success: `approve`, 0 findings |
| **Total** | — | **$2.59** | T-15 ships + 2 fixes + 2 carry-overs |

T-15 substantively cleared by the round-4 cold-reader: _"All three verify-line clauses are satisfied: FAB is mounted in App.tsx and hides on /incidents/active; both routes are added to the authenticated block in AppRoutes.tsx behind the incidentsEnabled flag; no spec drift, hidden coupling, or type-contract violations found."_

## Two fixes shipped

### 1. Cold-reader prompt — JSON-fenced-only (no prose preamble)

The cold-reader had been emitting `**Verdict: \`approve\` — no findings.**` as bold-prose preamble before the JSON. Strengthened the Output Format section with explicit prohibitions ("NO prose before or after the fence") and a methodology-basis line citing round 34. Snapshot regenerated.

**Caveat:** model compliance is non-deterministic. Run 2 of T-15's cold-reader (manual, post-fix) STILL emitted prose; run 3 produced clean JSON. The prompt change reduces the rate but doesn't eliminate it. Long-term fix candidate: parser fallback that extracts `verdict` from prose patterns. Not in this PR.

### 2. Orchestrator — capture `raw_result_text` on parse_error

When dispatch parse_error fires, the orchestrator's `dispatch_end` event payload now includes `raw_result_text` (in addition to `parse_error`). Round 34's first failure required a manual re-dispatch to see what cold-reader actually returned — state.json had the parse_error message but not the raw text. Fixed; future parse failures are debuggable from `state.json` alone. All 14 orchestrator tests still pass.

## Coverage gap caught by preflight

`incidentService.getIncident()` (added by the round-31 T-13 subagent as scope-creep) had no test → 75% functions vs. 80% threshold. Pre-push preflight caught it. Added 2 tests (round-trip + null path); back to 100%.

**Methodology gap surfaced:** orchestrator doesn't enforce coverage. Either extend the per-task verify line to include `pnpm run test:coverage` for the touched scope, or bake preflight into the orchestrator's post-build step. Logged; not in scope here.

## Cold-reader carry-over notes (logged for future PRs)

The cold-reader's run-3 notes flagged two real harness improvements:

1. **AC-N text not included in `cited_spec_sections`.** The renderer cites AC-18 by name but not the Given/When/Then body. Scope-2 checks can't trace properly. Carry-over: extend `cold-reader-input.ts`.
2. **Build-pass gate not verifiable by cold-reader.** T-15's verify line ends with "pnpm run build passes" — read-only cold-reader can't run commands. The orchestrator already verifies build via the builder's `verify_run`; cold-reader prompt should stop trying to assess command-execution clauses.

## Slice 1: 9/11 → 10/11

Remaining: **T-16 (manual smoke gate)**. Non-orchestratable by design (`pnpm run dev:with-emulators` → sign in → tap FAB → STOP → verify Firestore document). It's the slice-end human gate per plan §8.

The harness has now shipped 5 of 6 slice-1 builder-driven tasks (T-11..T-15) end-to-end. Cumulative spend across rounds 27-34: ~$11 to ship 5 commits + 7 methodology fixes (dispatcher resilience, verify-command derivation, final-verify-rerun, bypassPermissions, ESM/CJS interop, JSON-fenced-only cold-reader, orchestrator raw-text capture).

## Verify

- `pnpm preflight`: clean (lint + knip + build + test:coverage)
- `pnpm exec vitest run src/services/incidentService.test.ts`: 7/7 PASS (was 5/5)
- `pnpm exec vitest run scripts/harness/lib/orchestrate.test.ts`: 14/14 PASS

## Test plan

- [ ] CI green
- [ ] Reviewer skims `c9f6067` to confirm subagent's routes + App.tsx mount match T-15's verify line
- [ ] Reviewer reads the cold-reader prompt diff to confirm the prose-prohibition language