### PR TITLE
fix: freeze IncidentTimer when incident has endedAt

### DIFF
--- a/src/features/incidents/components/IncidentCaptureSurface.tsx
+++ b/src/features/incidents/components/IncidentCaptureSurface.tsx
@@ -14,7 +14,10 @@ export function IncidentCaptureSurface({
 }: IncidentCaptureSurfaceProps) {
   return (
     <Box>
-      <IncidentTimer startedAt={incident.startedAt} />
+      <IncidentTimer
+        startedAt={incident.startedAt}
+        endedAt={incident.endedAt}
+      />
       {incident.endedAt === null && <StopButton />}
     </Box>
   );

--- a/src/features/incidents/components/IncidentTimer.test.tsx
+++ b/src/features/incidents/components/IncidentTimer.test.tsx
@@ -31,6 +31,16 @@ describe('IncidentTimer', () => {
     expect(live).toHaveAttribute('aria-live', 'polite');
   });
 
+  it('freezes at the stopped duration when endedAt is provided (§D2 post-STOP)', () => {
+    const startedAt = new Date('2026-05-02T10:00:00.000Z');
+    const endedAt = new Date(startedAt.getTime() + 75_000);
+    vi.setSystemTime(new Date(startedAt.getTime() + 600_000));
+
+    render(<IncidentTimer startedAt={startedAt} endedAt={endedAt} />);
+
+    expect(screen.getByText('00:01:15')).toBeInTheDocument();
+  });
+
   it('uses monospace font-family per design §D9 (so digits do not jitter)', () => {
     const now = new Date('2026-05-02T10:00:00.000Z');
     vi.setSystemTime(now);

--- a/src/features/incidents/components/IncidentTimer.tsx
+++ b/src/features/incidents/components/IncidentTimer.tsx
@@ -3,13 +3,19 @@ import { useIncidentTimer } from '@features/incidents/hooks/useIncidentTimer';
 
 interface IncidentTimerProps {
   startedAt: Date;
+  endedAt?: Date | null;
 }
 
 // Per design §D9: monospace digits (no jitter), aria-live="polite" on the
 // elapsed text only — milliseconds are intentionally absent so screen
 // readers don't get flooded.
-export function IncidentTimer({ startedAt }: IncidentTimerProps) {
-  const elapsed = useIncidentTimer(startedAt);
+//
+// §D2 post-STOP invariant: endedAt freezes the displayed elapsed.
+export function IncidentTimer({
+  startedAt,
+  endedAt = null,
+}: IncidentTimerProps) {
+  const elapsed = useIncidentTimer(startedAt, endedAt);
 
   return (
     <Box

--- a/src/features/incidents/hooks/useIncidentTimer.test.ts
+++ b/src/features/incidents/hooks/useIncidentTimer.test.ts
@@ -42,6 +42,25 @@ describe('useIncidentTimer', () => {
     expect(result.current).toBe('00:00:00');
   });
 
+  it('freezes at endedAt - startedAt when endedAt is set (post-STOP §D2)', () => {
+    const startedAt = new Date('2026-05-02T10:00:00.000Z');
+    const endedAt = new Date(startedAt.getTime() + 90_000);
+    // Set "now" well past endedAt to prove the hook ignores it when frozen.
+    vi.setSystemTime(new Date(startedAt.getTime() + 600_000));
+
+    const { result } = renderHook(() => useIncidentTimer(startedAt, endedAt));
+
+    expect(result.current).toBe('00:01:30');
+
+    act(() => {
+      vi.setSystemTime(new Date(startedAt.getTime() + 700_000));
+      vi.advanceTimersByTime(300);
+    });
+
+    // Still frozen.
+    expect(result.current).toBe('00:01:30');
+  });
+
   it('re-renders as time advances (rAF + 250ms throttle per §D8)', () => {
     const start = new Date('2026-05-02T10:00:00.000Z');
     vi.setSystemTime(start);

--- a/src/features/incidents/hooks/useIncidentTimer.ts
+++ b/src/features/incidents/hooks/useIncidentTimer.ts
@@ -3,6 +3,10 @@ import { useEffect, useState } from 'react';
 // Per design §D8: render the timer with requestAnimationFrame, throttling
 // state updates to ~250ms (visible second resolution per BR-3, but smoother
 // to the eye). startedAt is the source of truth; elapsed is computed.
+//
+// Per §D2 post-STOP invariant (BR-14, BR-25, round-31 amend_design): when
+// endedAt is set, the timer freezes at endedAt - startedAt and the rAF loop
+// is skipped — the surface stays open showing the final duration.
 const TICK_THROTTLE_MS = 250;
 
 function formatElapsed(elapsedMs: number): string {
@@ -15,10 +19,15 @@ function formatElapsed(elapsedMs: number): string {
   return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
 }
 
-export function useIncidentTimer(startedAt: Date): string {
+export function useIncidentTimer(
+  startedAt: Date,
+  endedAt: Date | null = null
+): string {
   const [now, setNow] = useState(() => Date.now());
+  const isFrozen = endedAt !== null;
 
   useEffect(() => {
+    if (isFrozen) return;
     let rafId = 0;
     let lastTick = Date.now();
     const tick = () => {
@@ -31,7 +40,10 @@ export function useIncidentTimer(startedAt: Date): string {
     };
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, []);
+  }, [isFrozen]);
 
+  if (endedAt) {
+    return formatElapsed(endedAt.getTime() - startedAt.getTime());
+  }
   return formatElapsed(now - startedAt.getTime());
 }


### PR DESCRIPTION
## Summary
- Found during T-16 manual smoke: tapping STOP correctly hides the StopButton (per §D2 post-STOP invariant) but the timer kept ticking past the stop moment.
- Root cause: \`useIncidentTimer\` only took \`startedAt\` and computed \`now - startedAt\` every rAF tick — no awareness of \`endedAt\`.
- Fix: \`useIncidentTimer(startedAt, endedAt?)\` returns \`endedAt - startedAt\` and skips the rAF loop when \`endedAt\` is set. \`IncidentTimer\` accepts \`endedAt\`; \`IncidentCaptureSurface\` forwards \`incident.endedAt\`.

Cites §D2.

## Test plan
- [x] New test: \`useIncidentTimer\` freezes when \`endedAt\` is set, even as system time advances
- [x] New test: \`IncidentTimer\` renders the stopped duration, ignores wall-clock advance
- [x] Existing live-timer tests still pass (rAF path untouched when \`endedAt\` is null)
- [ ] Manual: T-16 retry — start incident, tap STOP, confirm timer freezes at the stopped duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)