### PR TITLE
feat(incidents): T-19 chipCatalog v1 content

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,6 +8,7 @@
   "project": ["src/**/*.{ts,tsx}"],
   "ignore": [
     "src/features/incidents/types.ts",
+    "src/features/incidents/chipCatalog.ts",
     "src/services/incidentService.ts",
     "src/store/useIncidentStore.ts"
   ],

--- a/src/features/incidents/chipCatalog.test.ts
+++ b/src/features/incidents/chipCatalog.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { chipCatalog } from './chipCatalog';
+import type { IncidentTypeId } from './types';
+
+const expectedTypes: IncidentTypeId[] = [
+  'seizure',
+  'injury',
+  'vomiting',
+  'choking',
+  'allergic_reaction',
+  'collapse',
+  'ingestion',
+  'other',
+];
+
+describe('chipCatalog', () => {
+  it('contains exactly the 8 v1 types from design §D5', () => {
+    expect(Object.keys(chipCatalog).sort()).toEqual([...expectedTypes].sort());
+  });
+
+  it('has at least one chip for every type except "other" (BR-32 / §D5)', () => {
+    for (const type of expectedTypes) {
+      if (type === 'other') {
+        expect(chipCatalog[type]).toEqual([]);
+        continue;
+      }
+      expect(chipCatalog[type].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('uses unique chip IDs within each type entry', () => {
+    for (const type of expectedTypes) {
+      const chips = chipCatalog[type];
+      expect(new Set(chips).size).toBe(chips.length);
+    }
+  });
+});

--- a/src/features/incidents/chipCatalog.ts
+++ b/src/features/incidents/chipCatalog.ts
@@ -1,0 +1,56 @@
+// Static chip catalog per incident type (resolves OQ-3, DQ-5). §D5
+// other has no curated chips in v1; journal is the only structured data for that type.
+import type { ChipId, IncidentTypeId } from './types';
+
+export const chipCatalog: Record<IncidentTypeId, readonly ChipId[]> = {
+  seizure: [
+    'rigid',
+    'salivating',
+    'unconscious',
+    'vocalizing',
+    'paddling',
+    'incontinence',
+    'blind',
+    'thirsty',
+  ],
+  injury: [
+    'bleeding',
+    'limping',
+    'swelling',
+    'vocalizing',
+    'exposed_wound',
+    'foreign_object',
+  ],
+  vomiting: ['food', 'bile', 'blood', 'foam', 'undigested', 'repeated'],
+  choking: [
+    'coughing',
+    'gagging',
+    'blue_gums',
+    'panicking',
+    'object_visible',
+    'collapsed',
+  ],
+  allergic_reaction: [
+    'facial_swelling',
+    'hives',
+    'itching',
+    'vomiting',
+    'breathing_difficulty',
+    'lethargy',
+  ],
+  collapse: [
+    'unresponsive',
+    'brief_loss',
+    'weak_pulse',
+    'pale_gums',
+    'recovered_quickly',
+  ],
+  ingestion: [
+    'known_substance',
+    'unknown_substance',
+    'vomited_already',
+    'lethargic',
+    'drooling',
+  ],
+  other: [],
+};


### PR DESCRIPTION
## Summary
- T-19: \`chipCatalog.ts\` with 8 incident types per design §D5 (seizure / injury / vomiting / choking / allergic_reaction / collapse / ingestion / other). Each entry maps to a readonly array of \`ChipId\` values.
- Orchestrated dispatch: \`harness orchestrate T-19\` shipped commit \`4b40b38\` first-try at \$0.57.
- Operator backfills: \`knip.json\` ignore (chipCatalog isn't imported until T-21 wires it into SeverityChips) + 3 shape tests (coverage gate failed without).

Cites OQ-3, §D5.

## Harness telemetry
| Metric | Value |
|--------|-------|
| Outcome | success (first-try) |
| Subagent cost | \$0.57 |
| Builder dispatches | 1 |
| Cold-reader verdicts | approve (0 findings) |
| Operator interventions | 2 (knip ignore + shape tests) |

## Harness lessons (logged in next round update)
- Both operator interventions are predictable forward-of-wire-up file additions: knip + coverage gates fire on any file that doesn't yet have a downstream consumer or test. Captured pattern for finding #8 candidate: harness should detect "introducing a file that lints clean but hasn't been wired in yet" and either auto-write a stub test + auto-update knip ignore, or warn the operator pre-push so the backfill happens before the failed push attempt.

## Test plan
- [x] preflight green (lint + knip + build + test:coverage)
- [x] 3 shape tests pass; coverage on chipCatalog.ts at 100%
- [x] knip.json no longer flags chipCatalog as unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)