### PR TITLE
feat(incidents): T-21 SeverityChips component

### DIFF
--- a/src/features/incidents/components/SeverityChips.test.tsx
+++ b/src/features/incidents/components/SeverityChips.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SeverityChips } from './SeverityChips';
+import type { Incident } from '@features/incidents/types';
+import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@store/useIncidentStore');
+
+function makeIncident(overrides: Partial<Incident> = {}): Incident {
+  const now = new Date('2026-05-02T10:00:00.000Z');
+  return {
+    id: 'inc-1',
+    userId: 'user-1',
+    createdBy: 'user-1',
+    petId: 'pet-1',
+    startedAt: now,
+    endedAt: null,
+    type: null,
+    severity: null,
+    chips: [],
+    journal: [],
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('SeverityChips (AC-2, BR-6)', () => {
+  const mockSetSeverity = vi.fn().mockResolvedValue(undefined);
+  const mockClearSeverity = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      setSeverity: mockSetSeverity,
+      clearSeverity: mockClearSeverity,
+    } as unknown as IncidentState);
+  });
+
+  it('AC-2: Given active incident with no severity, When caregiver taps mild, Then setSeverity called with mild', async () => {
+    const user = userEvent.setup();
+    render(<SeverityChips incident={makeIncident({ severity: null })} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'incidents.severity.mild' })
+    );
+
+    expect(mockSetSeverity).toHaveBeenCalledWith('mild');
+    expect(mockClearSeverity).not.toHaveBeenCalled();
+  });
+
+  it('AC-2: Given active incident with mild selected, When caregiver taps mild again, Then clearSeverity called', async () => {
+    const user = userEvent.setup();
+    render(<SeverityChips incident={makeIncident({ severity: 'mild' })} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'incidents.severity.mild' })
+    );
+
+    expect(mockClearSeverity).toHaveBeenCalledTimes(1);
+    expect(mockSetSeverity).not.toHaveBeenCalled();
+  });
+
+  it('AC-2: Given active incident with mild selected, When caregiver taps severe, Then setSeverity called with severe', async () => {
+    const user = userEvent.setup();
+    render(<SeverityChips incident={makeIncident({ severity: 'mild' })} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'incidents.severity.severe' })
+    );
+
+    expect(mockSetSeverity).toHaveBeenCalledWith('severe');
+    expect(mockClearSeverity).not.toHaveBeenCalled();
+  });
+
+  it('aria-pressed reflects selection state (NFR-6)', () => {
+    render(<SeverityChips incident={makeIncident({ severity: 'moderate' })} />);
+
+    expect(
+      screen.getByRole('button', { name: 'incidents.severity.mild' })
+    ).toHaveAttribute('aria-pressed', 'false');
+    expect(
+      screen.getByRole('button', { name: 'incidents.severity.moderate' })
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      screen.getByRole('button', { name: 'incidents.severity.severe' })
+    ).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/src/features/incidents/components/SeverityChips.tsx
+++ b/src/features/incidents/components/SeverityChips.tsx
@@ -1,0 +1,45 @@
+import { Box, Chip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useIncidentStore } from '@store/useIncidentStore';
+import type { Incident, Severity } from '@features/incidents/types';
+
+// BR-6: severity is settable, changeable, and clearable by single-tap chip
+// interaction. §D9: MUI Chip with role="button" and aria-pressed. NFR-3: 44×44
+// minimum tap target.
+
+const SEVERITIES: Severity[] = ['mild', 'moderate', 'severe'];
+
+interface SeverityChipsProps {
+  incident: Incident;
+}
+
+export function SeverityChips({ incident }: SeverityChipsProps) {
+  const { t } = useTranslation();
+  const { setSeverity, clearSeverity } = useIncidentStore();
+
+  const handleTap = (severity: Severity) => {
+    if (incident.severity === severity) {
+      void clearSeverity();
+    } else {
+      void setSeverity(severity);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', gap: 1 }}>
+      {SEVERITIES.map((severity) => {
+        const selected = incident.severity === severity;
+        return (
+          <Chip
+            key={severity}
+            label={t(`incidents.severity.${severity}`)}
+            onClick={() => handleTap(severity)}
+            aria-pressed={selected}
+            color={selected ? 'primary' : 'default'}
+            sx={{ minHeight: 44, minWidth: 44 }}
+          />
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/store/useIncidentStore.test.ts
+++ b/src/store/useIncidentStore.test.ts
@@ -10,6 +10,8 @@ vi.mock('@services/incidentService', () => ({
     createIncident: vi.fn(),
     stopIncident: vi.fn(),
     findActiveIncident: vi.fn(),
+    setSeverity: vi.fn(),
+    clearSeverity: vi.fn(),
   },
 }));
 
@@ -156,6 +158,68 @@ describe('useIncidentStore', () => {
       });
 
       expect(incidentService.stopIncident).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setSeverity / clearSeverity (BR-6)', () => {
+    it('sets severity optimistically and persists via service', async () => {
+      vi.mocked(incidentService.setSeverity).mockResolvedValue(
+        fakeActive({ severity: 'moderate' })
+      );
+      useIncidentStore.setState({ activeIncident: fakeActive() });
+
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.setSeverity('moderate');
+      });
+
+      expect(result.current.activeIncident?.severity).toBe('moderate');
+      expect(incidentService.setSeverity).toHaveBeenCalledWith(
+        'user-1',
+        'incident-1',
+        'moderate'
+      );
+    });
+
+    it('no-ops setSeverity when no active incident', async () => {
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.setSeverity('mild');
+      });
+      expect(incidentService.setSeverity).not.toHaveBeenCalled();
+    });
+
+    it('clears severity optimistically and persists via service', async () => {
+      vi.mocked(incidentService.clearSeverity).mockResolvedValue(
+        fakeActive({ severity: null })
+      );
+      useIncidentStore.setState({
+        activeIncident: fakeActive({ severity: 'severe' }),
+      });
+
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.clearSeverity();
+      });
+
+      expect(result.current.activeIncident?.severity).toBeNull();
+      expect(incidentService.clearSeverity).toHaveBeenCalledWith(
+        'user-1',
+        'incident-1'
+      );
+    });
+
+    it('captures error on setSeverity persist failure', async () => {
+      vi.mocked(incidentService.setSeverity).mockRejectedValue(
+        new Error('boom')
+      );
+      useIncidentStore.setState({ activeIncident: fakeActive() });
+
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.setSeverity('mild');
+      });
+      expect(result.current.error).toBe('boom');
     });
   });
 

--- a/src/store/useIncidentStore.test.ts
+++ b/src/store/useIncidentStore.test.ts
@@ -181,6 +181,26 @@ describe('useIncidentStore', () => {
       );
     });
 
+    it('no-ops clearSeverity when no active incident', async () => {
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.clearSeverity();
+      });
+      expect(incidentService.clearSeverity).not.toHaveBeenCalled();
+    });
+
+    it('captures error on clearSeverity persist failure', async () => {
+      vi.mocked(incidentService.clearSeverity).mockRejectedValue(
+        new Error('clear-fail')
+      );
+      useIncidentStore.setState({ activeIncident: fakeActive() });
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.clearSeverity();
+      });
+      expect(result.current.error).toBe('clear-fail');
+    });
+
     it('no-ops setSeverity when no active incident', async () => {
       const { result } = renderHook(() => useIncidentStore());
       await act(async () => {

--- a/src/store/useIncidentStore.ts
+++ b/src/store/useIncidentStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { incidentService } from '@services/incidentService';
 import { useAuthStore } from '@store/auth.store';
-import type { Incident } from '@features/incidents/types';
+import type { Incident, Severity } from '@features/incidents/types';
 
 // Per design §D8 NFR-2: startIncident generates the UUID and startedAt
 // synchronously, sets activeIncident, then persists in the background.
@@ -22,6 +22,10 @@ export interface IncidentState {
   startIncident: (args: { petId: string }) => Promise<void>;
   stopIncident: () => Promise<void>;
   hydrateActiveIncident: () => Promise<void>;
+  // BR-6: severity is settable, changeable, clearable by single-tap chip interaction.
+  // Paired chore added in T-21 — service methods existed; store surface was missing.
+  setSeverity: (severity: Severity) => Promise<void>;
+  clearSeverity: () => Promise<void>;
 }
 
 function buildOptimisticIncident(
@@ -103,6 +107,40 @@ export const useIncidentStore = create(
         set({
           error:
             error instanceof Error ? error.message : 'Failed to stop incident',
+        });
+      }
+    },
+
+    setSeverity: async (severity) => {
+      const active = get().activeIncident;
+      const userId = useAuthStore.getState().user?.uid;
+      if (!active || !userId) return;
+
+      set({ activeIncident: { ...active, severity }, error: null });
+
+      try {
+        await incidentService.setSeverity(userId, active.id, severity);
+      } catch (error) {
+        set({
+          error:
+            error instanceof Error ? error.message : 'Failed to set severity',
+        });
+      }
+    },
+
+    clearSeverity: async () => {
+      const active = get().activeIncident;
+      const userId = useAuthStore.getState().user?.uid;
+      if (!active || !userId) return;
+
+      set({ activeIncident: { ...active, severity: null }, error: null });
+
+      try {
+        await incidentService.clearSeverity(userId, active.id);
+      } catch (error) {
+        set({
+          error:
+            error instanceof Error ? error.message : 'Failed to clear severity',
         });
       }
     },


### PR DESCRIPTION
## Summary
- T-21: \`SeverityChips\` component (3-up MUI grid, mild/moderate/severe). AC-2 toggle behavior: tap selected = clear, tap other = replace. \`aria-pressed\` per §D9 a11y, 44×44 tap target per NFR-3.
- Builder also added paired chore commit \`4f85647\` exposing \`setSeverity\` / \`clearSeverity\` on \`useIncidentStore\` (T-17 added them to incidentService but not the store). Pre-flight protocol caught the gap; builder added as scope-extension chore rather than escalating as spec_gap.
- Operator backfilled 6 store-level tests across two commits (statement coverage 64.46% → ~80%, branch coverage 69.56% → ≥70%).

Cites BR-6, NFR-3, NFR-6, §D2, §D9.

## Harness telemetry
| Metric | Value |
|--------|-------|
| Builder cost | \$1.43 |
| Cold-reader cost | included in orchestrator total |
| Outcome | success (orchestrator chained cleanly this time, no SHA hallucination) |
| Operator interventions | 2 (coverage-gate backfill — added 6 store tests in 2 commits) |

## Harness lessons
- Round-36 finding #6 firing again: builder's paired chore commit added store wrappers without tests. Cold-reader scope #2 ("AC has a test") doesn't catch it because the chore is a scope-extension, not part of the cited ACs.
- Builder pre-flight protocol working as designed — the missing-store-method check fired and the builder chose the right escalation tier (paired chore, not spec_gap).

## Test plan
- [x] preflight green; coverage gates met
- [x] AC-2 component tests pass; aria-pressed asserted
- [x] All four store wrapper paths covered (set/clear × happy/no-active/error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)