### PR TITLE
feat(incidents): T-22 IncidentJournal component (post-pushback)

### DIFF
--- a/src/features/incidents/components/IncidentJournal.test.tsx
+++ b/src/features/incidents/components/IncidentJournal.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IncidentJournal } from './IncidentJournal';
+import { useIncidentStore } from '@store/useIncidentStore';
+import type { Incident } from '@features/incidents/types';
+
+vi.mock('@store/useIncidentStore', () => ({
+  useIncidentStore: vi.fn(),
+}));
+
+const fakeActive = (over: Partial<Incident> = {}): Incident => ({
+  id: 'incident-1',
+  userId: 'user-1',
+  createdBy: 'user-1',
+  petId: 'pet-1',
+  startedAt: new Date('2026-05-02T10:00:00.000Z'),
+  endedAt: null,
+  type: null,
+  severity: null,
+  chips: [],
+  journal: [],
+  deletedAt: null,
+  createdAt: new Date('2026-05-02T10:00:00.000Z'),
+  updatedAt: new Date('2026-05-02T10:00:00.000Z'),
+  ...over,
+});
+
+describe('IncidentJournal', () => {
+  const mockAppendJournal = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      activeIncident: fakeActive(),
+      appendJournal: mockAppendJournal,
+      isLoading: false,
+      error: null,
+      startIncident: vi.fn(),
+      stopIncident: vi.fn(),
+      hydrateActiveIncident: vi.fn(),
+      setSeverity: vi.fn(),
+      clearSeverity: vi.fn(),
+    });
+  });
+
+  it('AC-4 Given/When/Then: appends journal entry on Enter with elapsed time prefix', async () => {
+    const user = userEvent.setup();
+    render(<IncidentJournal />);
+
+    const textarea = screen.getByRole('textbox', { name: /journal/i });
+    await user.type(textarea, 'shaking starting');
+    await user.keyboard('{Enter}');
+
+    expect(mockAppendJournal).toHaveBeenCalledWith('shaking starting');
+    // After append, the textarea should be cleared
+    expect(textarea).toHaveValue('');
+  });
+
+  it('displays existing journal entries with elapsed time prefix', () => {
+    vi.mocked(useIncidentStore).mockReturnValue({
+      activeIncident: fakeActive({
+        journal: [
+          {
+            elapsedSeconds: 92,
+            text: 'shaking starting',
+            addedAt: new Date('2026-05-02T10:01:32.000Z'),
+          },
+          {
+            elapsedSeconds: 150,
+            text: 'still shaking',
+            addedAt: new Date('2026-05-02T10:02:30.000Z'),
+          },
+        ],
+      }),
+      appendJournal: mockAppendJournal,
+      isLoading: false,
+      error: null,
+      startIncident: vi.fn(),
+      stopIncident: vi.fn(),
+      hydrateActiveIncident: vi.fn(),
+      setSeverity: vi.fn(),
+      clearSeverity: vi.fn(),
+    });
+
+    render(<IncidentJournal />);
+
+    // Entries should display with HH:MM:SS prefix
+    expect(screen.getByText(/00:01:32/)).toBeInTheDocument();
+    expect(screen.getByText(/shaking starting/)).toBeInTheDocument();
+    expect(screen.getByText(/00:02:30/)).toBeInTheDocument();
+    expect(screen.getByText(/still shaking/)).toBeInTheDocument();
+  });
+
+  it('backspace does not delete committed journal lines', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      activeIncident: fakeActive({
+        journal: [
+          {
+            elapsedSeconds: 92,
+            text: 'shaking starting',
+            addedAt: new Date('2026-05-02T10:01:32.000Z'),
+          },
+        ],
+      }),
+      appendJournal: mockAppendJournal,
+      isLoading: false,
+      error: null,
+      startIncident: vi.fn(),
+      stopIncident: vi.fn(),
+      hydrateActiveIncident: vi.fn(),
+      setSeverity: vi.fn(),
+      clearSeverity: vi.fn(),
+    });
+
+    render(<IncidentJournal />);
+
+    const textarea = screen.getByRole('textbox', { name: /journal/i });
+    await user.click(textarea);
+    await user.keyboard('{Backspace}');
+
+    // Committed entry should still be visible
+    expect(screen.getByText(/00:01:32/)).toBeInTheDocument();
+    expect(screen.getByText(/shaking starting/)).toBeInTheDocument();
+  });
+
+  it('multi-line paste creates one entry (up to first newline), rest stays in input', async () => {
+    const user = userEvent.setup();
+    render(<IncidentJournal />);
+
+    const textarea = screen.getByRole('textbox', { name: /journal/i });
+    const multiLineText = 'first line\nsecond line\nthird line';
+
+    await user.click(textarea);
+    await user.paste(multiLineText);
+
+    // The full pasted text should be in the textarea initially
+    expect(textarea).toHaveValue(multiLineText);
+
+    // When user presses Enter, only the first line should be appended
+    await user.keyboard('{Enter}');
+    expect(mockAppendJournal).toHaveBeenCalledWith('first line');
+  });
+
+  it('does not append empty text', async () => {
+    const user = userEvent.setup();
+    render(<IncidentJournal />);
+
+    const textarea = screen.getByRole('textbox', { name: /journal/i });
+    await user.click(textarea);
+    await user.keyboard('{Enter}');
+
+    expect(mockAppendJournal).not.toHaveBeenCalled();
+  });
+
+  it('does not append whitespace-only text', async () => {
+    const user = userEvent.setup();
+    render(<IncidentJournal />);
+
+    const textarea = screen.getByRole('textbox', { name: /journal/i });
+    await user.type(textarea, '   ');
+    await user.keyboard('{Enter}');
+
+    expect(mockAppendJournal).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/incidents/components/IncidentJournal.tsx
+++ b/src/features/incidents/components/IncidentJournal.tsx
@@ -1,0 +1,66 @@
+import { useState, type KeyboardEvent, type ChangeEvent } from 'react';
+import { TextField, Box, Typography } from '@mui/material';
+import { useIncidentStore } from '@store/useIncidentStore';
+
+function formatElapsedTime(elapsedSeconds: number): string {
+  const hours = Math.floor(elapsedSeconds / 3600);
+  const minutes = Math.floor((elapsedSeconds % 3600) / 60);
+  const seconds = elapsedSeconds % 60;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}
+
+export function IncidentJournal() {
+  const { activeIncident, appendJournal } = useIncidentStore();
+  const [inputText, setInputText] = useState('');
+
+  const handleKeyDown = async (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+
+      // Extract first line (up to first newline, if any)
+      const firstLine = inputText.split('\n')[0] || '';
+      const trimmed = firstLine.trim();
+
+      if (trimmed) {
+        await appendJournal(trimmed);
+        setInputText('');
+      }
+    }
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setInputText(e.target.value);
+  };
+
+  return (
+    <Box>
+      {activeIncident && activeIncident.journal.length > 0 && (
+        <Box mb={2}>
+          {activeIncident.journal.map((entry, index) => (
+            <Box key={index} mb={1}>
+              <Typography variant="body2" component="span" fontWeight="bold">
+                {formatElapsedTime(entry.elapsedSeconds)}
+              </Typography>
+              <Typography variant="body2" component="span" ml={1}>
+                {entry.text}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <TextField
+        multiline
+        fullWidth
+        minRows={3}
+        maxRows={8}
+        value={inputText}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        label="Journal"
+        placeholder="Press Enter to commit entry..."
+        aria-label="Journal"
+      />
+    </Box>
+  );
+}

--- a/src/store/useIncidentStore.test.ts
+++ b/src/store/useIncidentStore.test.ts
@@ -12,6 +12,7 @@ vi.mock('@services/incidentService', () => ({
     findActiveIncident: vi.fn(),
     setSeverity: vi.fn(),
     clearSeverity: vi.fn(),
+    appendJournal: vi.fn(),
   },
 }));
 
@@ -269,6 +270,84 @@ describe('useIncidentStore', () => {
       });
 
       expect(result.current.activeIncident).toBeNull();
+    });
+  });
+
+  describe('appendJournal (BR-8, BR-9, BR-30, AC-4)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('AC-4: Given an active incident 92s old, When appendJournal is called, Then optimistic entry has elapsedSeconds = 92', async () => {
+      const startedAt = new Date('2026-05-02T10:00:00.000Z');
+      vi.setSystemTime(new Date(startedAt.getTime() + 92_000));
+      vi.mocked(incidentService.appendJournal).mockResolvedValue(
+        fakeActive({ startedAt, journal: [] })
+      );
+      useIncidentStore.setState({ activeIncident: fakeActive({ startedAt }) });
+
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.appendJournal('shaking starting');
+      });
+
+      const entries = result.current.activeIncident!.journal;
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.elapsedSeconds).toBe(92);
+      expect(entries[0]!.text).toBe('shaking starting');
+
+      // Service receives the SAME `now` the store used — guarantees persisted
+      // elapsedSeconds matches the optimistic value (no ms drift).
+      expect(incidentService.appendJournal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          incidentId: 'incident-1',
+          text: 'shaking starting',
+          now: expect.any(Date),
+        })
+      );
+      const passedNow = vi.mocked(incidentService.appendJournal).mock
+        .calls[0]![0].now!;
+      expect(
+        Math.floor((passedNow.getTime() - startedAt.getTime()) / 1000)
+      ).toBe(92);
+    });
+
+    it('is a no-op when no active incident exists', async () => {
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.appendJournal('some text');
+      });
+
+      expect(incidentService.appendJournal).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no auth user exists', async () => {
+      (useAuthStore.getState as Mock).mockReturnValue({ user: null });
+      useIncidentStore.setState({ activeIncident: fakeActive() });
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.appendJournal('some text');
+      });
+
+      expect(incidentService.appendJournal).not.toHaveBeenCalled();
+    });
+
+    it('captures error on persist failure', async () => {
+      vi.mocked(incidentService.appendJournal).mockRejectedValue(
+        new Error('append-fail')
+      );
+      useIncidentStore.setState({ activeIncident: fakeActive() });
+      const { result } = renderHook(() => useIncidentStore());
+      await act(async () => {
+        await result.current.appendJournal('some text');
+      });
+
+      expect(result.current.error).toBe('append-fail');
     });
   });
 });

--- a/src/store/useIncidentStore.ts
+++ b/src/store/useIncidentStore.ts
@@ -26,6 +26,8 @@ export interface IncidentState {
   // Paired chore added in T-21 — service methods existed; store surface was missing.
   setSeverity: (severity: Severity) => Promise<void>;
   clearSeverity: () => Promise<void>;
+  // BR-8, BR-9: append journal entry with elapsed time
+  appendJournal: (text: string) => Promise<void>;
 }
 
 function buildOptimisticIncident(
@@ -158,6 +160,42 @@ export const useIncidentStore = create(
             error instanceof Error
               ? error.message
               : 'Failed to hydrate incident',
+        });
+      }
+    },
+
+    appendJournal: async (text: string) => {
+      const active = get().activeIncident;
+      const userId = useAuthStore.getState().user?.uid;
+      if (!active || !userId) return;
+
+      const now = new Date();
+      const elapsedSeconds = Math.floor(
+        (now.getTime() - active.startedAt.getTime()) / 1000
+      );
+
+      const newEntry = {
+        elapsedSeconds,
+        text,
+        addedAt: now,
+      };
+
+      set({
+        activeIncident: { ...active, journal: [...active.journal, newEntry] },
+        error: null,
+      });
+
+      try {
+        await incidentService.appendJournal({
+          userId,
+          incidentId: active.id,
+          text,
+          now,
+        });
+      } catch (error) {
+        set({
+          error:
+            error instanceof Error ? error.message : 'Failed to append journal',
         });
       }
     },


### PR DESCRIPTION
## Summary
- T-22: \`IncidentJournal\` component (textarea + Enter-commit + paste-up-to-first-newline rule + auto-prefix display) + paired \`appendJournal\` action on \`useIncidentStore\`.
- **First fully orchestrated build → review → veto → operator-pushback → re-build cycle.** Orchestrator's first attempt (commit \`07eb20e\`, \$2.04) shipped the component and store action correctly but missed AC-4's \`elapsedSeconds=92\` test assertion. Cold-reader vetoed (scope_check 2: AC has no test).
- Orchestrator routed correctly per its rule: scope_check 1-2 = builder error → halt for human (no auto-arbiter). Operator pulled the cold-reader's finding text via \`harness review T-22 --diff <sha>~1..<sha>\`, drafted pushback, re-dispatched builder via \`claude -p\` with the cold-reader finding + concrete test scaffold inline.
- Re-dispatch (commit \`b4eaddc\`, \$0.76) added 4 store-level tests including the AC-4 elapsedSeconds=92 assertion, plus reproduced the previous attempt's correct component + store action verbatim.

Cites BR-8, BR-9, BR-30, AC-4, §D5 DQ-4.

## Harness telemetry
| Metric | Value |
|--------|-------|
| Builder attempt 1 (orchestrated) | \$1.77 |
| Cold-reader (orchestrator) | \$0.28 |
| Cold-reader (manual re-dispatch to recover finding text) | \$0.32 |
| Builder attempt 2 (manual pushback) | \$0.76 |
| **Total** | **\$3.13** |
| Outcome | success after one pushback cycle |

## Harness lessons
- **Finding #6 fired again with prejudice.** Cold-reader scope #2 ("AC has a test") DID catch the gap this time — first time it has caught what operator would have caught. Suggests the prompt is improving (or AC-4's specific Then clause is concrete enough that scope #2 can trace it). Worth contrasting with T-17's miss.
- **Finding #10 (new): state.json doesn't store cold-reader finding text.** When the orchestrator halted, the operator had to re-dispatch the cold-reader (\$0.32) just to see what the verdict was about. Capture cold-reader's full \`findings\` array in the dispatch_end payload — adds maybe 1KB per dispatch, eliminates the re-dispatch cost on every veto.
- **Finding #11 (new): no \`harness pushback\` CLI still hurts.** This pushback took ~12 min of operator time (read findings, draft pushback with concrete test scaffold, render input, append, shell out). Each pushback re-dispatch costs ~\$0.66-\$0.76 LLM + ~10-15 min operator. Promotes #7 from PR-B candidate to "should ship before slice 3."

## Test plan
- [x] preflight green (1111 tests pass)
- [x] AC-4 elapsedSeconds=92 asserted at store layer
- [x] Component test asserts text-only call (component layer); store test asserts elapsedSeconds-derivation (store layer); incidentService.test asserts service \`now\` injection (T-17). Three layers, three responsibilities, all tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)