### PR TITLE
feat(incidents): T-23 ObservationChips component

### DIFF
--- a/src/features/incidents/components/ObservationChips.test.tsx
+++ b/src/features/incidents/components/ObservationChips.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ObservationChips } from './ObservationChips';
+import type { Incident } from '@features/incidents/types';
+import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@store/useIncidentStore');
+
+function makeIncident(overrides: Partial<Incident> = {}): Incident {
+  const now = new Date('2026-05-02T10:00:00.000Z');
+  return {
+    id: 'inc-1',
+    userId: 'user-1',
+    createdBy: 'user-1',
+    petId: 'pet-1',
+    startedAt: now,
+    endedAt: null,
+    type: null,
+    severity: null,
+    chips: [],
+    journal: [],
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('ObservationChips (AC-3, AC-21, BR-7, BR-32)', () => {
+  const mockToggleChip = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      toggleChip: mockToggleChip,
+    } as unknown as IncidentState);
+  });
+
+  describe('AC-3 — toggle without type (BR-7, BR-4)', () => {
+    it('Given no type and a toggled-on chip, the chip is visible in the carry-over group', () => {
+      render(
+        <ObservationChips
+          incident={makeIncident({ type: null, chips: ['rigid'] })}
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'incidents.chips.rigid' })
+      ).toBeInTheDocument();
+    });
+
+    it('Given no type, When caregiver taps a carry-over chip, Then toggleChip fires with that chipId', async () => {
+      const user = userEvent.setup();
+      render(
+        <ObservationChips
+          incident={makeIncident({ type: null, chips: ['rigid'] })}
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'incidents.chips.rigid' })
+      );
+
+      expect(mockToggleChip).toHaveBeenCalledWith('rigid');
+    });
+
+    it('Given no type and no chips, Then no chip buttons render (empty container, no error)', () => {
+      render(
+        <ObservationChips incident={makeIncident({ type: null, chips: [] })} />
+      );
+      expect(screen.queryAllByRole('button')).toHaveLength(0);
+    });
+  });
+
+  describe('AC-21 — carry-over chips visible after type change (BR-19, BR-32)', () => {
+    it('Given type=injury with chips including seizure-specific "rigid", Then injury catalog renders and "rigid" appears in carry-over', () => {
+      // 'vocalizing' is in both seizure + injury catalogs → curated
+      // 'rigid' is seizure-specific, not in injury catalog → carry-over
+      render(
+        <ObservationChips
+          incident={makeIncident({
+            type: 'injury',
+            chips: ['vocalizing', 'rigid'],
+          })}
+        />
+      );
+
+      // injury curated chip present
+      expect(
+        screen.getByRole('button', { name: 'incidents.chips.bleeding' })
+      ).toBeInTheDocument();
+
+      // carry-over chip from seizure catalog remains visible
+      expect(
+        screen.getByRole('button', { name: 'incidents.chips.rigid' })
+      ).toBeInTheDocument();
+    });
+
+    it('Given type=injury, When caregiver taps carry-over chip "rigid", Then toggleChip called with "rigid"', async () => {
+      const user = userEvent.setup();
+      render(
+        <ObservationChips
+          incident={makeIncident({
+            type: 'injury',
+            chips: ['vocalizing', 'rigid'],
+          })}
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'incidents.chips.rigid' })
+      );
+
+      expect(mockToggleChip).toHaveBeenCalledWith('rigid');
+    });
+
+    it('Carry-over chip has aria-pressed=true (it is toggled on by definition, BR-32)', () => {
+      render(
+        <ObservationChips
+          incident={makeIncident({ type: 'injury', chips: ['rigid'] })}
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'incidents.chips.rigid' })
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('Seizure chip not toggled on and not in injury catalog is absent from render', () => {
+      render(
+        <ObservationChips
+          incident={makeIncident({ type: 'injury', chips: [] })}
+        />
+      );
+
+      expect(
+        screen.queryByRole('button', { name: 'incidents.chips.rigid' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('curated chips — aria-pressed and toggle (NFR-6, BR-7)', () => {
+    it('aria-pressed reflects toggle state on curated chips', () => {
+      render(
+        <ObservationChips
+          incident={makeIncident({ type: 'seizure', chips: ['rigid'] })}
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'incidents.chips.rigid' })
+      ).toHaveAttribute('aria-pressed', 'true');
+      expect(
+        screen.getByRole('button', { name: 'incidents.chips.salivating' })
+      ).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('Tapping an untoggled curated chip calls toggleChip with its id', async () => {
+      const user = userEvent.setup();
+      render(
+        <ObservationChips
+          incident={makeIncident({ type: 'seizure', chips: [] })}
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'incidents.chips.rigid' })
+      );
+
+      expect(mockToggleChip).toHaveBeenCalledWith('rigid');
+    });
+
+    it('All injury catalog chips render when type=injury', () => {
+      render(
+        <ObservationChips
+          incident={makeIncident({ type: 'injury', chips: [] })}
+        />
+      );
+
+      for (const chipId of [
+        'bleeding',
+        'limping',
+        'swelling',
+        'vocalizing',
+        'exposed_wound',
+        'foreign_object',
+      ]) {
+        expect(
+          screen.getByRole('button', { name: `incidents.chips.${chipId}` })
+        ).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/src/features/incidents/components/ObservationChips.tsx
+++ b/src/features/incidents/components/ObservationChips.tsx
@@ -1,0 +1,62 @@
+import { Box, Chip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useIncidentStore } from '@store/useIncidentStore';
+import type { Incident } from '@features/incidents/types';
+import { chipCatalog } from '../chipCatalog';
+
+// BR-7: chips toggleable by single-tap, no required minimum (no type required).
+// BR-19: curated chip catalog updates when type changes.
+// BR-32: toggled-on chips absent from the curated catalog remain visible in a
+//        "carried over" group so caregivers don't perceive silent data loss.
+// §D9: MUI Chip rendered as toggle button (aria-pressed). NFR-3: 44×44 tap target.
+
+interface ObservationChipsProps {
+  incident: Incident;
+}
+
+export function ObservationChips({ incident }: ObservationChipsProps) {
+  const { t } = useTranslation();
+  const { toggleChip } = useIncidentStore();
+
+  const curatedChips = incident.type ? [...chipCatalog[incident.type]] : [];
+  const curatedSet = new Set(curatedChips);
+  const carryOverChips = incident.chips.filter((c) => !curatedSet.has(c));
+
+  const handleTap = (chipId: string) => {
+    void toggleChip(chipId);
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        {curatedChips.map((chipId) => {
+          const selected = incident.chips.includes(chipId);
+          return (
+            <Chip
+              key={chipId}
+              label={t(`incidents.chips.${chipId}`)}
+              onClick={() => handleTap(chipId)}
+              aria-pressed={selected}
+              color={selected ? 'primary' : 'default'}
+              sx={{ minHeight: 44, minWidth: 44 }}
+            />
+          );
+        })}
+      </Box>
+      {carryOverChips.length > 0 && (
+        <Box sx={{ mt: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {carryOverChips.map((chipId) => (
+            <Chip
+              key={chipId}
+              label={t(`incidents.chips.${chipId}`)}
+              onClick={() => handleTap(chipId)}
+              aria-pressed={true}
+              color="primary"
+              sx={{ minHeight: 44, minWidth: 44 }}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/store/useIncidentStore.ts
+++ b/src/store/useIncidentStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { incidentService } from '@services/incidentService';
 import { useAuthStore } from '@store/auth.store';
-import type { Incident, Severity } from '@features/incidents/types';
+import type { ChipId, Incident, Severity } from '@features/incidents/types';
 
 // Per design §D8 NFR-2: startIncident generates the UUID and startedAt
 // synchronously, sets activeIncident, then persists in the background.
@@ -28,6 +28,9 @@ export interface IncidentState {
   clearSeverity: () => Promise<void>;
   // BR-8, BR-9: append journal entry with elapsed time
   appendJournal: (text: string) => Promise<void>;
+  // BR-7: chips toggleable by single-tap, no required minimum.
+  // Paired chore added in T-23 — service/repo existed; store surface was missing.
+  toggleChip: (chipId: ChipId) => Promise<void>;
 }
 
 function buildOptimisticIncident(
@@ -160,6 +163,27 @@ export const useIncidentStore = create(
             error instanceof Error
               ? error.message
               : 'Failed to hydrate incident',
+        });
+      }
+    },
+
+    toggleChip: async (chipId) => {
+      const active = get().activeIncident;
+      const userId = useAuthStore.getState().user?.uid;
+      if (!active || !userId) return;
+
+      const nextChips = active.chips.includes(chipId)
+        ? active.chips.filter((c) => c !== chipId)
+        : [...active.chips, chipId];
+
+      set({ activeIncident: { ...active, chips: nextChips }, error: null });
+
+      try {
+        await incidentService.toggleChip(userId, active.id, chipId);
+      } catch (error) {
+        set({
+          error:
+            error instanceof Error ? error.message : 'Failed to toggle chip',
         });
       }
     },


### PR DESCRIPTION
## Summary
- T-23: \`ObservationChips\` component. Reads \`chipCatalog[incident.type]\` to render the curated set; renders any toggled-on chips NOT in the current catalog as a separate "carried over" group (BR-32). Both groups toggleable.
- Paired chore: \`toggleChip\` action on \`useIncidentStore\` (same pattern as T-21's setSeverity addition).
- Orchestrated dispatch: first-try success, no operator pushback needed. Reported SHA matched real this time (finding #9 still probabilistic).

Cites BR-7, BR-19, BR-32, AC-3, AC-21, §D5.

## Harness telemetry
| Metric | Value |
|--------|-------|
| Total cost | \$1.50 (orchestrator-reported) |
| Builder dispatches | 1 |
| Cold-reader verdict | approve |
| Outcome | success first-try |
| Operator interventions | 0 |

## Test plan
- [x] preflight green
- [x] AC-3 (toggle without type) tested
- [x] AC-21 (carry-over chip after type change) tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)