### PR TITLE
feat(incidents): T-25 IncidentCaptureSurface (full assembly)

### DIFF
--- a/src/features/incidents/components/IncidentCaptureSurface.test.tsx
+++ b/src/features/incidents/components/IncidentCaptureSurface.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { IncidentCaptureSurface } from './IncidentCaptureSurface';
 import type { Incident } from '@features/incidents/types';
 import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
@@ -14,6 +15,23 @@ vi.mock('@store/useIncidentStore');
 
 vi.mock('@features/incidents/hooks/useIncidentTimer', () => ({
   useIncidentTimer: () => '00:01:05',
+}));
+
+// Mock child components to isolate surface composition
+vi.mock('./SeverityChips', () => ({
+  SeverityChips: () => <div data-testid="severity-chips" />,
+}));
+
+vi.mock('./ObservationChips', () => ({
+  ObservationChips: () => <div data-testid="observation-chips" />,
+}));
+
+vi.mock('./IncidentJournal', () => ({
+  IncidentJournal: () => <div data-testid="incident-journal" />,
+}));
+
+vi.mock('./VetCallCard', () => ({
+  VetCallCard: () => <div data-testid="vet-call-card" />,
 }));
 
 function makeIncident(overrides: Partial<Incident> = {}): Incident {
@@ -46,25 +64,48 @@ describe('IncidentCaptureSurface', () => {
     } as unknown as IncidentState);
   });
 
-  it('renders timer and STOP button given an active incident (endedAt === null, BR-14)', () => {
-    const incident = makeIncident({ endedAt: null });
-    render(<IncidentCaptureSurface incident={incident} />);
+  describe('active state (endedAt === null)', () => {
+    it('renders full surface: timer, STOP button, and all sub-sections', () => {
+      render(<IncidentCaptureSurface incident={makeIncident()} />);
 
-    expect(screen.getByText('00:01:05')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'incidents.stop' })
-    ).toBeInTheDocument();
+      expect(screen.getByText('00:01:05')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'incidents.stop' })
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('severity-chips')).toBeInTheDocument();
+      expect(screen.getByTestId('observation-chips')).toBeInTheDocument();
+      expect(screen.getByTestId('incident-journal')).toBeInTheDocument();
+      expect(screen.getByTestId('vet-call-card')).toBeInTheDocument();
+    });
   });
 
-  it('renders timer but no STOP button given a stopped incident (endedAt !== null, BR-25)', () => {
-    const incident = makeIncident({
-      endedAt: new Date('2026-05-02T10:01:05.000Z'),
-    });
-    render(<IncidentCaptureSurface incident={incident} />);
+  describe('stopped state (endedAt !== null, BR-14, BR-25)', () => {
+    it('renders full surface without STOP button; all other sections stay mounted', () => {
+      const incident = makeIncident({
+        endedAt: new Date('2026-05-02T10:01:05.000Z'),
+      });
+      render(<IncidentCaptureSurface incident={incident} />);
 
+      expect(screen.getByText('00:01:05')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'incidents.stop' })
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('severity-chips')).toBeInTheDocument();
+      expect(screen.getByTestId('observation-chips')).toBeInTheDocument();
+      expect(screen.getByTestId('incident-journal')).toBeInTheDocument();
+      expect(screen.getByTestId('vet-call-card')).toBeInTheDocument();
+    });
+  });
+
+  it('STOP click calls stopIncident and surface stays mounted (BR-14)', async () => {
+    const user = userEvent.setup();
+    render(<IncidentCaptureSurface incident={makeIncident()} />);
+
+    await user.click(screen.getByRole('button', { name: 'incidents.stop' }));
+
+    expect(mockStopIncident).toHaveBeenCalledOnce();
+    // Surface stays mounted — BR-14 requires no navigation away
     expect(screen.getByText('00:01:05')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'incidents.stop' })
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('severity-chips')).toBeInTheDocument();
   });
 });

--- a/src/features/incidents/components/IncidentCaptureSurface.test.tsx
+++ b/src/features/incidents/components/IncidentCaptureSurface.test.tsx
@@ -17,6 +17,14 @@ vi.mock('@features/incidents/hooks/useIncidentTimer', () => ({
   useIncidentTimer: () => '00:01:05',
 }));
 
+const mockTimerProps = vi.fn();
+vi.mock('./IncidentTimer', () => ({
+  IncidentTimer: (props: { startedAt: Date; endedAt: Date | null }) => {
+    mockTimerProps(props);
+    return <div data-testid="incident-timer">00:01:05</div>;
+  },
+}));
+
 // Mock child components to isolate surface composition
 vi.mock('./SeverityChips', () => ({
   SeverityChips: () => <div data-testid="severity-chips" />,
@@ -95,6 +103,27 @@ describe('IncidentCaptureSurface', () => {
       expect(screen.getByTestId('incident-journal')).toBeInTheDocument();
       expect(screen.getByTestId('vet-call-card')).toBeInTheDocument();
     });
+  });
+
+  it('forwards incident.endedAt to IncidentTimer so timer freezes post-stop (BR-14)', () => {
+    const startedAt = new Date('2026-05-02T10:00:00.000Z');
+    const endedAt = new Date(startedAt.getTime() + 65_000);
+
+    // Active: endedAt is null → timer runs live
+    const { rerender } = render(
+      <IncidentCaptureSurface incident={makeIncident({ startedAt })} />
+    );
+    expect(mockTimerProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({ startedAt, endedAt: null })
+    );
+
+    // Stopped: endedAt is set → timer is given the freeze prop
+    rerender(
+      <IncidentCaptureSurface incident={makeIncident({ startedAt, endedAt })} />
+    );
+    expect(mockTimerProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({ startedAt, endedAt })
+    );
   });
 
   it('STOP click calls stopIncident and surface stays mounted (BR-14)', async () => {

--- a/src/features/incidents/components/IncidentCaptureSurface.tsx
+++ b/src/features/incidents/components/IncidentCaptureSurface.tsx
@@ -1,6 +1,10 @@
 import { Box } from '@mui/material';
 import { IncidentTimer } from './IncidentTimer';
 import { StopButton } from './StopButton';
+import { SeverityChips } from './SeverityChips';
+import { ObservationChips } from './ObservationChips';
+import { IncidentJournal } from './IncidentJournal';
+import { VetCallCard } from './VetCallCard';
 import type { Incident } from '@features/incidents/types';
 
 interface IncidentCaptureSurfaceProps {
@@ -13,12 +17,16 @@ export function IncidentCaptureSurface({
   incident,
 }: IncidentCaptureSurfaceProps) {
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <IncidentTimer
         startedAt={incident.startedAt}
         endedAt={incident.endedAt}
       />
       {incident.endedAt === null && <StopButton />}
+      <SeverityChips incident={incident} />
+      <ObservationChips incident={incident} />
+      <IncidentJournal />
+      <VetCallCard petId={incident.petId} />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- T-25: extends \`IncidentCaptureSurface\` (T-12) to compose \`SeverityChips\`, \`ObservationChips\`, \`IncidentJournal\`, \`VetCallCard\`, plus existing \`IncidentTimer\` + \`StopButton\`. Same component renders in active and stopped states (BR-14, BR-25 unification).
- **Cold-reader verdict non-determinism** (new finding #12): orchestrator's first cold-reader run returned \`veto\` on BR-14 with 1 finding (scope_check 2: missing test). Operator re-dispatched cold-reader on the IDENTICAL diff to read the finding text (per finding #10) — got \`approve\` with 0 findings. Same prompt, same input, opposite verdicts.
- The original gap is real: line-100 STOP-click test verified surface stays mounted but did not verify the timer freezes (used static props that don't react to clicks). Operator added a tighter freeze-prop assertion test in commit \`971c49b\` so the BR-14 contract is locked at the composition layer.

Cites BR-14, BR-25, §D2.

## Harness telemetry
| Metric | Value |
|--------|-------|
| Builder | \$0.66 |
| Cold-reader (orchestrator, veto) | \$0.35 |
| Cold-reader (operator re-dispatch, approve) | \$0.25 |
| **Total** | **\$1.26** |
| Outcome | success after operator-added test (no builder re-dispatch) |
| Operator interventions | 2 (cold-reader re-dispatch + 1 backfill test) |

## Harness lessons (for next round update)
- **Finding #12 (new): cold-reader verdict non-determinism on identical input.** Same diff, same prompt, opposite verdicts in two consecutive runs. Different from format-compliance non-determinism (round 34) — this is *judgment* non-determinism. Mitigations: (a) run cold-reader N=3 and majority-vote, (b) lower temperature, (c) accept and rely on operator review as the consistency layer. Worth quantifying: rerun the same diff 5x and measure verdict stability before deciding on a fix.
- **Finding #10 still unaddressed.** Re-dispatch ($0.25) was needed to read the verdict's finding text. State.json should capture full finding bodies.
- The operator's first-pass diff inspection (5 min) correctly identified the gap before re-dispatch returned. For tasks with concrete cited ACs, operator review is consistently faster than waiting on a re-dispatch.

## Test plan
- [x] preflight green
- [x] Active state: full surface renders with all sub-sections + STOP button
- [x] Stopped state: STOP button hidden, all sub-sections stay mounted
- [x] STOP click: stopIncident called, surface stays mounted
- [x] **NEW**: IncidentTimer receives endedAt prop (active=null, stopped=Date) — locks BR-14 freeze contract at composition layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)