### PR TITLE
feat(harness): PR-B-2 cold-reader sees task body + scope #7 (#6)

### DIFF
--- a/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
+++ b/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
@@ -15,7 +15,11 @@ gates merge.
 You receive:
 
 - **`task_id`** — e.g. `T-07`
-- **`task_description`** — verbatim from the task list
+- **`task_description`** — verbatim one-line summary
+- **`task_what`** — verbatim "What" line from the task body. **This is the
+  task's contract.** Every method/symbol/file/option named here is a
+  verbatim requirement; renaming, collapsing, or omitting any named entity
+  is a divergence (see scope_check 7).
 - **`cited_spec_sections`** — verbatim text of every spec section/requirement
   the task cites. You may NOT infer beyond what's here. If the spec doesn't
   explicitly say something, the spec doesn't say it.
@@ -35,7 +39,7 @@ context.
 ## POSITIVE SCOPE (the only things you check for)
 
 For each finding you emit, the `scope_check` field MUST be one of these
-six numbers. If a concern doesn't fit one of these, do not emit it.
+seven numbers. If a concern doesn't fit one of these, do not emit it.
 
 1. **Spec implementation correctness.** For each cited BR, trace the BR's
    text to a specific code line. If the diff doesn't implement what the BR
@@ -67,6 +71,20 @@ six numbers. If a concern doesn't fit one of these, do not emit it.
    section are mutually satisfiable.** Methodology basis: round-25
    builder pre-flight caught this on T-06 after five rounds of design
    cold-reads missed it.
+7. **Task contract conformance** (added round 42, finding #6). Read the
+   `task_what` input verbatim. For every method name, symbol, file path,
+   option, or behavior named there, check that the diff implements it
+   with the **exact name** given. Renaming (`setSeverity` accepting `null`
+   instead of separate `setSeverity` + `clearSeverity` when both are
+   named), collapsing (4 methods where 6 are named), reshaping (caller-
+   supplied arg where the task says service computes), or omitting any
+   named entity is a divergence. Emit as **CRITICAL** if the omission
+   breaks a contract callers will rely on; **HIGH** if it's silently
+   collapsing a named symmetry. Methodology basis: T-17 (round 37) shipped
+   with two such divergences and cold-reader missed both because it had
+   no access to the task body — the cited BRs were too loose to constrain
+   the API shape. The `task_what` field exists precisely so this scope
+   has bite.
 
 ---
 
@@ -131,7 +149,7 @@ observations — use it freely, but keep it inside the JSON.
 }
 ```
 
-**Methodology basis:** round-34 cold-reader emitted `**Verdict: \`approve\` — no findings.**` as bold-prose preamble before the JSON-shaped notes; parser found no `verdict` field; orchestrator halted at $0.55 for a clean approve. JSON-fenced-only is the operationally correct format because it's what the parser is built for.
+**Methodology basis:** round-34 cold-reader emitted `**Verdict: \`approve\` — no findings.\*\*`as bold-prose preamble before the JSON-shaped notes; parser found no`verdict` field; orchestrator halted at $0.55 for a clean approve. JSON-fenced-only is the operationally correct format because it's what the parser is built for.
 
 **`cited_section` MUST be one of: `BR-N`, `NFR-N`, `AC-N`, `US-N`, `OQ-N`,
 `DQ-N`, `§N`, `§DN`.** No other values are valid. Findings rooted in the
@@ -175,6 +193,14 @@ ground truth for whether your scoping is right. Trust it over your instincts.
 # Task under review: T-01 — TypeScript types
 
 **Verify line (per-task gate):** `pnpm exec tsc -b` passes with the new file imported nowhere.
+
+## Task contract (verbatim "What" line)
+
+_The 'What' line is the verbatim contract for this task. Treat every
+method/symbol/file/option named here as a verbatim requirement; renaming,
+collapsing, or omitting any named entity is a divergence (see scope_check 7)._
+
+Create `src/features/incidents/types.ts` with `Incident`, `IncidentTypeId`, `Severity`, `ChipId`, `JournalEntry`, `IncidentCreateInput`, `IncidentUpdateInput`. Include the BR-29 runtime-invariant comment from design §D3.
 
 ## Cited spec sections
 

--- a/scripts/harness/evals/cold-reader/cases/regression/T-17-code-all-six-methods-named.json
+++ b/scripts/harness/evals/cold-reader/cases/regression/T-17-code-all-six-methods-named.json
@@ -1,0 +1,20 @@
+{
+  "case_id": "regression-T-17-all-six-methods-named",
+  "artifact_kind": "code",
+  "task_id": "T-17",
+  "source": "Positive (approve) twin of T-17-collapsed-named-methods. Same task_what; this diff implements all six named methods as separate exports. Cold-reader should approve on the scope-7 dimension (no scope-7 finding emitted).",
+  "input": {
+    "task_description": "incidentService extensions (mutations)",
+    "task_what": "Add to incidentService: setSeverity, clearSeverity, toggleChip, appendJournal (computes elapsedSeconds against incident.startedAt at call time per BR-31), setType, clearType. All use repository methods that wrap RMW per design §D3.",
+    "verify_line": "Unit tests for each method; tests cover the BR-22 invariant (changing type leaves severity, chips, journal untouched) and BR-31 (elapsedSeconds stored at write time, not recomputed).",
+    "cited_spec_refs": ["BR-6", "BR-7", "BR-8", "BR-9", "BR-19", "BR-22"],
+    "cited_design_refs": ["§D3"],
+    "diff_summary": "incidentService.ts exports 6 distinct methods: setSeverity(userId, incidentId, severity), clearSeverity(userId, incidentId), toggleChip(userId, incidentId, chipId), appendJournal({ userId, incidentId, text, now? }), setType(userId, incidentId, type), clearType(userId, incidentId). All six methods named exactly per the task contract. Tests cover all six method paths plus BR-22 invariant and BR-31 service-side computation.",
+    "diff_path": "fixtures/T-17-all-six-methods.diff"
+  },
+  "expected": {
+    "verdict": "approve",
+    "findings": []
+  },
+  "notes": "Positive control for scope_check 7. If scope #7 starts firing on this diff, the prompt has drifted into over-strict mode (e.g., requiring exact arg shape rather than named-symbol presence). The arg shape can vary (positional vs object) as long as the named symbols exist; that's a different scope concern (#3 silent design choice, scope #6 type-contract conformance) caught by other tests."
+}

--- a/scripts/harness/evals/cold-reader/cases/regression/T-17-code-collapsed-named-methods.json
+++ b/scripts/harness/evals/cold-reader/cases/regression/T-17-code-collapsed-named-methods.json
@@ -1,0 +1,28 @@
+{
+  "case_id": "regression-T-17-collapsed-named-methods",
+  "artifact_kind": "code",
+  "task_id": "T-17",
+  "source": "Real builder divergence from round 37 (T-17). Surfaced finding #6: cold-reader scope #1 (BR coverage) was satisfied because each cited BR had some test, but the task's 'What' line explicitly named SIX distinct mutation methods (setSeverity, clearSeverity, toggleChip, appendJournal, setType, clearType) and the builder shipped only FOUR (collapsed clearSeverity into setSeverity(null) and clearType into setType(null)). Cold-reader missed both divergences pre-PR-B-2 because the prompt didn't load task_what.",
+  "input": {
+    "task_description": "incidentService extensions (mutations)",
+    "task_what": "Add to incidentService: setSeverity, clearSeverity, toggleChip, appendJournal (computes elapsedSeconds against incident.startedAt at call time per BR-31), setType, clearType. All use repository methods that wrap RMW per design §D3.",
+    "verify_line": "Unit tests for each method; tests cover the BR-22 invariant (changing type leaves severity, chips, journal untouched) and BR-31 (elapsedSeconds stored at write time, not recomputed).",
+    "cited_spec_refs": ["BR-6", "BR-7", "BR-8", "BR-9", "BR-19", "BR-22"],
+    "cited_design_refs": ["§D3"],
+    "diff_summary": "incidentService.ts exports 4 methods: setSeverity(args: { severity: Severity | null }), setType(args: { type: IncidentTypeId | null }), toggleChip, appendJournal. No clearSeverity. No clearType. Tests cover all 4 method paths including null-handling.",
+    "diff_path": "fixtures/T-17-collapsed-methods.diff"
+  },
+  "expected": {
+    "verdict": "veto",
+    "findings": [
+      {
+        "severity": "HIGH",
+        "scope_check": 7,
+        "cited_section": ["task_what"],
+        "evidence_pattern": "(?i)setSeverity|setType|null|clearSeverity|clearType",
+        "description_pattern": "(?i)clearSeverity|clearType|six|named|verbatim|exact name|collapse|nullable"
+      }
+    ]
+  },
+  "notes": "Single-finding case demonstrating scope_check 7 firing. The cold-reader should: (a) read task_what verbatim, (b) enumerate the six named symbols, (c) cross-check against the diff, (d) emit a HIGH finding flagging clearSeverity + clearType as missing. Severity is HIGH (not CRITICAL) per the scope-7 rubric: silently collapsing a named symmetry is HIGH; a contract-breaking omission would be CRITICAL. This case predates PR-B-2 (it's the empirical motivation for finding #6's resolution) and is the regression test that scope_check 7 must keep passing."
+}

--- a/scripts/harness/lib/cold-reader-input.test.ts
+++ b/scripts/harness/lib/cold-reader-input.test.ts
@@ -55,6 +55,28 @@ describe('buildColdReaderInput — T-01 with a sample diff', () => {
     expect(input.task_description).toMatch(/TypeScript types/);
   });
 
+  it('carries the verbatim task_what for scope_check 7 (finding #6)', () => {
+    expect(input.task_what).not.toBeNull();
+    // T-01's What line names the file path and exported types — the
+    // scope-7-relevant content cold-reader needs.
+    expect(input.task_what!).toMatch(/types\.ts/);
+    expect(input.task_what!).toMatch(/Incident/);
+  });
+
+  it('renders a Task contract section in the markdown when task_what is set', () => {
+    const md = formatColdReaderInputMarkdown(input);
+    expect(md).toMatch(/## Task contract \(verbatim "What" line\)/);
+    expect(md).toMatch(/scope_check 7/);
+  });
+
+  it('omits the Task contract section when task_what is null', () => {
+    const md = formatColdReaderInputMarkdown({
+      ...input,
+      task_what: null,
+    });
+    expect(md).not.toMatch(/## Task contract/);
+  });
+
   it('extracts the cited spec/design sections (separated)', () => {
     expect(input.cited_spec_sections.map((c) => c.ref)).toEqual(['§5']);
     expect(input.cited_design_sections.map((c) => c.ref)).toEqual(['§D3']);

--- a/scripts/harness/lib/cold-reader-input.ts
+++ b/scripts/harness/lib/cold-reader-input.ts
@@ -14,6 +14,12 @@ import type { Citation, Task } from './task-parser';
 export interface ColdReaderInput {
   task_id: string;
   task_description: string;
+  /** The verbatim "What" line from the task body. Per finding #6 (round 37,
+   * widened round 39): cold-reader needs this to evaluate scope_check 7
+   * (does the diff implement every method/symbol/file named here, with the
+   * exact names given). Without this, scope #1 only sees BR coverage at the
+   * spec level, which is too loose. */
+  task_what: string | null;
   /** Per-spec methodology: the cold-reader sees verbatim cited regions only,
    * not the full spec/design. The flat list keeps the prompt deterministic. */
   cited_spec_sections: Array<{ ref: string; body: string }>;
@@ -62,6 +68,7 @@ export function buildColdReaderInput(
   return {
     task_id: task.id,
     task_description: task.description,
+    task_what: task.what,
     cited_spec_sections: specCites,
     cited_design_sections: designCites,
     verify_line: task.verify,
@@ -118,6 +125,23 @@ export function formatColdReaderInputMarkdown(input: ColdReaderInput): string {
 
   if (input.verify_line) {
     out.push(`**Verify line (per-task gate):** ${input.verify_line}`);
+    out.push('');
+  }
+
+  if (input.task_what) {
+    out.push('## Task contract (verbatim "What" line)');
+    out.push('');
+    out.push(
+      "_The 'What' line is the verbatim contract for this task. Treat every"
+    );
+    out.push(
+      'method/symbol/file/option named here as a verbatim requirement; renaming,'
+    );
+    out.push(
+      'collapsing, or omitting any named entity is a divergence (see scope_check 7)._'
+    );
+    out.push('');
+    out.push(input.task_what.trim());
     out.push('');
   }
 

--- a/scripts/harness/lib/prompts/cold-reader-code.md
+++ b/scripts/harness/lib/prompts/cold-reader-code.md
@@ -15,7 +15,11 @@ gates merge.
 You receive:
 
 - **`task_id`** — e.g. `T-07`
-- **`task_description`** — verbatim from the task list
+- **`task_description`** — verbatim one-line summary
+- **`task_what`** — verbatim "What" line from the task body. **This is the
+  task's contract.** Every method/symbol/file/option named here is a
+  verbatim requirement; renaming, collapsing, or omitting any named entity
+  is a divergence (see scope_check 7).
 - **`cited_spec_sections`** — verbatim text of every spec section/requirement
   the task cites. You may NOT infer beyond what's here. If the spec doesn't
   explicitly say something, the spec doesn't say it.
@@ -35,7 +39,7 @@ context.
 ## POSITIVE SCOPE (the only things you check for)
 
 For each finding you emit, the `scope_check` field MUST be one of these
-six numbers. If a concern doesn't fit one of these, do not emit it.
+seven numbers. If a concern doesn't fit one of these, do not emit it.
 
 1. **Spec implementation correctness.** For each cited BR, trace the BR's
    text to a specific code line. If the diff doesn't implement what the BR
@@ -67,6 +71,20 @@ six numbers. If a concern doesn't fit one of these, do not emit it.
    section are mutually satisfiable.** Methodology basis: round-25
    builder pre-flight caught this on T-06 after five rounds of design
    cold-reads missed it.
+7. **Task contract conformance** (added round 42, finding #6). Read the
+   `task_what` input verbatim. For every method name, symbol, file path,
+   option, or behavior named there, check that the diff implements it
+   with the **exact name** given. Renaming (`setSeverity` accepting `null`
+   instead of separate `setSeverity` + `clearSeverity` when both are
+   named), collapsing (4 methods where 6 are named), reshaping (caller-
+   supplied arg where the task says service computes), or omitting any
+   named entity is a divergence. Emit as **CRITICAL** if the omission
+   breaks a contract callers will rely on; **HIGH** if it's silently
+   collapsing a named symmetry. Methodology basis: T-17 (round 37) shipped
+   with two such divergences and cold-reader missed both because it had
+   no access to the task body — the cited BRs were too loose to constrain
+   the API shape. The `task_what` field exists precisely so this scope
+   has bite.
 
 ---
 


### PR DESCRIPTION
## Summary
PR-B / PR-2 of 3. Closes finding #6 (round 37, widened round 39).

The cold-reader prompt previously received only \`task_description\` (the one-line summary). The task body's "What" line — the verbatim contract for what symbols/methods/files must exist — was invisible. T-17 shipped two divergences cold-reader missed because cited BRs were too loose to constrain API shape.

This PR closes the gap by:
1. Adding \`task_what\` to \`ColdReaderInput\` and rendering it in a new "## Task contract (verbatim 'What' line)" markdown section
2. Adding positive scope #7 to \`cold-reader-code.md\`: read \`task_what\` verbatim; renaming/collapsing/reshaping/omitting any named symbol is a divergence
3. Regenerating the \`cold-read-T-01-no-diff\` snapshot (intentional diff per §9)
4. Adding 2 new regression eval cases (T-17 collapsed-methods negative + all-six positive control)

Cites §11 (PR-B PR-2 of 3).

## Test plan
- [x] preflight green (1132 tests pass; 3 new)
- [x] Snapshot regen verified (Task contract section now appears in rendered prompt)
- [x] 2 new cold-reader eval cases load via shape validator

## Hand-test (post-merge)
Re-render \`pnpm tsx scripts/harness/cli.ts cold-read T-17 --diff <SHA>~1..<SHA>\` against any historical T-17 commit. Cold-reader should now see the verbatim 6-method "What" line that originally got silently collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)