### PR TITLE
feat(harness): PR-B-3 `harness pushback` CLI (#7, #11)

### DIFF
--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -46,6 +46,7 @@ import {
   orchestrateTask,
   summarizeOrchestrateResult,
 } from './lib/orchestrate.ts';
+import { dispatchPushback } from './lib/pushback-dispatch.ts';
 import { dirname, join } from 'node:path';
 import { execSync } from 'node:child_process';
 
@@ -83,6 +84,12 @@ function usage(): string {
     '  orchestrate <task-id>      Chain build → review → (arbiter+apply) until',
     '                             success, halt for human, or hit a cap. Logs',
     '                             every step to .harness/state.json.',
+    '  pushback <task-id>         Re-dispatch builder with operator findings as',
+    '                             explicit context. Use --findings <path> to',
+    '                             point at a markdown file with findings; pass',
+    '                             --reset to first `git reset --hard HEAD~1`',
+    '                             (discards the previous orchestrator commit).',
+    '                             Logs a pushback_dispatch event to state.json.',
     '',
     'Options:',
     `  --file <path>              Task list to read (default: ${DEFAULT_TASK_FILE}).`,
@@ -92,6 +99,8 @@ function usage(): string {
     '                             (e.g. `main..HEAD`). Defaults to the current',
     '                             uncommitted diff for cold-read and HEAD~1..HEAD',
     '                             for review.',
+    '  --findings <path>          For pushback: markdown file with operator findings.',
+    '  --reset                    For pushback: `git reset --hard HEAD~1` first.',
     '  -h, --help                 Show this help.',
   ].join('\n');
 }
@@ -223,6 +232,8 @@ function main(): void {
       help: { type: 'boolean', short: 'h', default: false },
       'no-system-prompt': { type: 'boolean', default: false },
       diff: { type: 'string' },
+      findings: { type: 'string' },
+      reset: { type: 'boolean', default: false },
     },
     allowPositionals: true,
   });
@@ -560,6 +571,33 @@ function main(): void {
       );
       break;
     }
+    case 'pushback': {
+      const taskId = positionals[1];
+      if (!taskId) {
+        fail(
+          'pushback requires a task id (e.g. T-22) and --findings <path>\n\n' +
+            usage()
+        );
+      }
+      if (!values.findings) {
+        fail(
+          'pushback requires --findings <path> (markdown file with operator findings)\n\n' +
+            usage()
+        );
+      }
+      void runPushback(
+        taskId,
+        values.findings,
+        values.reset === true,
+        filePath,
+        fileArg,
+        values.json
+      ).catch((err) => {
+        const reason = err instanceof Error ? err.message : String(err);
+        fail(`pushback failed: ${reason}`);
+      });
+      break;
+    }
     default:
       fail(`unknown command '${command}'\n\n${usage()}`);
   }
@@ -795,6 +833,64 @@ async function runOrchestrate(
     process.stdout.write(`state log: .harness/state.json\n`);
   }
   process.exit(result.outcome === 'success' ? 0 : 2);
+}
+
+async function runPushback(
+  taskId: string,
+  findingsPath: string,
+  reset: boolean,
+  filePath: string,
+  fileArg: string,
+  json: boolean
+): Promise<void> {
+  process.stderr.write(
+    `harness: pushback re-dispatch for ${taskId} (findings: ${findingsPath}${reset ? ', after git reset --hard HEAD~1' : ''})...\n`
+  );
+  const result = await dispatchPushback({
+    taskId,
+    findingsPath,
+    reset,
+    taskListPath: filePath,
+  });
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          file: fileArg,
+          task_id: taskId,
+          findings_source: findingsPath,
+          reset,
+          status: result.exit?.status ?? null,
+          parse_error: result.parseError ?? null,
+          commit_sha: result.commitSha ?? null,
+          cost_usd: result.raw.costUsd,
+          duration_ms: result.raw.durationMs,
+          num_turns: result.raw.numTurns,
+          state_path: '.harness/state.json',
+        },
+        null,
+        2
+      )}\n`
+    );
+  } else {
+    process.stdout.write(`pushback: ${result.exit?.status ?? 'parse_error'}\n`);
+    process.stdout.write(`  cost: $${result.raw.costUsd.toFixed(4)}\n`);
+    process.stdout.write(
+      `  duration: ${(result.raw.durationMs / 1000).toFixed(1)}s\n`
+    );
+    process.stdout.write(`  num_turns: ${result.raw.numTurns}\n`);
+    if (result.commitSha) {
+      process.stdout.write(`  commit_sha: ${result.commitSha}\n`);
+    }
+    if (result.parseError) {
+      process.stdout.write(`  parse_error: ${result.parseError}\n`);
+      process.stdout.write(
+        `  raw_result_text (last 1000 chars):\n---\n${result.raw.resultText.slice(-1000)}\n---\n`
+      );
+    }
+    process.stdout.write(`state log: .harness/state.json\n`);
+  }
+  process.exit(result.exit?.status === 'success' ? 0 : 2);
 }
 
 main();

--- a/scripts/harness/lib/pushback-dispatch.test.ts
+++ b/scripts/harness/lib/pushback-dispatch.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { dispatchPushback, buildPushbackSection } from './pushback-dispatch';
+
+// Minimal fake-spawn helper, modeled on subagent-dispatch.test.ts.
+interface FakeChild extends EventEmitter {
+  stdin: Writable;
+  stdout: Readable;
+  stderr: Readable;
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeFakeChild(opts: {
+  stdoutChunks?: string[];
+  exitCode: number | null;
+  capturedStdin?: string[];
+}): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdin = new Writable({
+    write(chunk, _enc, cb) {
+      opts.capturedStdin?.push(chunk.toString());
+      cb();
+    },
+    final(cb) {
+      cb();
+    },
+  });
+  child.stdout = Readable.from((opts.stdoutChunks ?? []).map(Buffer.from));
+  child.stderr = Readable.from([]);
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  child.killed = false;
+  setTimeout(() => child.emit('exit', opts.exitCode), 5);
+  return child;
+}
+
+const SUCCESS_ENVELOPE = JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  result:
+    '```json\n{"status":"success","commit_sha":"hallucinated-deadbeef"}\n```',
+  stop_reason: 'end_turn',
+  session_id: 'pb-session-1',
+  total_cost_usd: 0.66,
+  duration_ms: 9000,
+  num_turns: 12,
+});
+
+let workDir: string;
+let specDir: string;
+let statePath: string;
+let findingsPath: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'pushback-'));
+  specDir = join(workDir, 'docs/specs/incident-capture');
+  mkdirSync(specDir, { recursive: true });
+
+  // Minimal task list with one task; build off the project's real format.
+  writeFileSync(
+    join(specDir, '03-tasks.md'),
+    [
+      '# Tasks',
+      '',
+      'Status legend: `[ ]` not started · `[x]` done.',
+      '',
+      '## Slice T — test',
+      '',
+      '### `[x]` T-99 — test task',
+      '',
+      '- **Cite:** spec BR-1; design §D1',
+      '- **What:** do the thing per BR-1.',
+      '- **Verify:** unit tests pass.',
+      '',
+    ].join('\n'),
+    'utf8'
+  );
+  writeFileSync(
+    join(specDir, '01-spec.md'),
+    '# Spec\n\n## §1 Foo\n\n- **BR-1** — must do the thing.\n',
+    'utf8'
+  );
+  writeFileSync(
+    join(specDir, '02-design.md'),
+    '# Design\n\n## §D1 Foo\n\nThe design.\n',
+    'utf8'
+  );
+
+  // Builder system prompt (minimal real-shape stub).
+  mkdirSync(join(workDir, 'scripts/harness/lib/prompts'), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+    '# Builder\n\nYou are the builder.\n',
+    'utf8'
+  );
+
+  statePath = join(workDir, '.harness/state.json');
+
+  findingsPath = join(workDir, 'pushback.md');
+  writeFileSync(
+    findingsPath,
+    '### Pushback A\n\nFix the divergence.\n',
+    'utf8'
+  );
+});
+
+describe('buildPushbackSection', () => {
+  it('produces the standard ## Operator pushback re-dispatch section with verbatim findings body', () => {
+    const section = buildPushbackSection('### One\n\nDo X.\n');
+    expect(section).toContain('## Operator pushback re-dispatch');
+    expect(section).toContain('### One');
+    expect(section).toContain('Do X.');
+  });
+
+  it('trims trailing whitespace from the findings body', () => {
+    const section = buildPushbackSection('the body\n\n\n\n');
+    expect(section.endsWith('the body')).toBe(true);
+  });
+});
+
+describe('dispatchPushback — file & validation', () => {
+  it('throws when findings file does not exist', async () => {
+    await expect(
+      dispatchPushback({
+        taskId: 'T-99',
+        findingsPath: 'nope.md',
+        cwd: workDir,
+        statePath,
+        taskListPath: join(specDir, '03-tasks.md'),
+        promptPath: join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+      })
+    ).rejects.toThrow(/findings file not found/);
+  });
+
+  it('throws when findings file is empty', async () => {
+    writeFileSync(findingsPath, '   \n\n', 'utf8');
+    await expect(
+      dispatchPushback({
+        taskId: 'T-99',
+        findingsPath,
+        cwd: workDir,
+        statePath,
+        taskListPath: join(specDir, '03-tasks.md'),
+        promptPath: join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+      })
+    ).rejects.toThrow(/findings file is empty/);
+  });
+
+  it('throws when task ID does not exist in the task list', async () => {
+    await expect(
+      dispatchPushback({
+        taskId: 'T-NOPE',
+        findingsPath,
+        cwd: workDir,
+        statePath,
+        taskListPath: join(specDir, '03-tasks.md'),
+        promptPath: join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+      })
+    ).rejects.toThrow(/task T-NOPE not found/);
+  });
+
+  it('refuses to reset when HEAD~1 does not exist', async () => {
+    // Default reset impl shells to git; inject a custom one that mimics the failure.
+    await expect(
+      dispatchPushback({
+        taskId: 'T-99',
+        findingsPath,
+        reset: true,
+        cwd: workDir,
+        statePath,
+        taskListPath: join(specDir, '03-tasks.md'),
+        promptPath: join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+        resetImpl: () => {
+          throw new Error(
+            'pushback dispatch: --reset requested but HEAD~1 does not exist (refusing to reset on an initial commit)'
+          );
+        },
+        spawnImpl: vi.fn() as never,
+      })
+    ).rejects.toThrow(/HEAD~1 does not exist/);
+  });
+});
+
+describe('dispatchPushback — happy path', () => {
+  it('renders builder input + appended pushback section, dispatches, and logs pushback_dispatch event', async () => {
+    const captured: string[] = [];
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({
+        stdoutChunks: [SUCCESS_ENVELOPE],
+        exitCode: 0,
+        capturedStdin: captured,
+      })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await dispatchPushback({
+      taskId: 'T-99',
+      findingsPath,
+      cwd: workDir,
+      statePath,
+      taskListPath: join(specDir, '03-tasks.md'),
+      promptPath: join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+      spawnImpl,
+      resolveHeadShaImpl: () => 'real-head-sha-123',
+    });
+
+    expect(result.exit?.status).toBe('success');
+    expect(result.commitSha).toBe('real-head-sha-123');
+    expect(result.parseError).toBeUndefined();
+
+    // The prompt sent to the subagent must include both the standard builder
+    // input AND the operator-pushback section.
+    const sentPrompt = captured.join('');
+    expect(sentPrompt).toContain('You are the builder.');
+    expect(sentPrompt).toContain('## Operator pushback re-dispatch');
+    expect(sentPrompt).toContain('### Pushback A');
+
+    // state.json captures the pushback_dispatch event with cost/duration/sha.
+    expect(existsSync(statePath)).toBe(true);
+    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+    const events = state.events as Array<{
+      type: string;
+      payload: Record<string, unknown>;
+    }>;
+    const pb = events.find((e) => e.type === 'pushback_dispatch');
+    expect(pb).toBeTruthy();
+    expect(pb!.payload.cost_usd).toBe(0.66);
+    expect(pb!.payload.commit_sha).toBe('real-head-sha-123');
+    expect(pb!.payload.findings_source).toBe(findingsPath);
+    expect(pb!.payload.reset).toBe(false);
+  });
+
+  it('runs reset before dispatch when reset=true', async () => {
+    const resetImpl = vi.fn();
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: [SUCCESS_ENVELOPE], exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await dispatchPushback({
+      taskId: 'T-99',
+      findingsPath,
+      reset: true,
+      cwd: workDir,
+      statePath,
+      taskListPath: join(specDir, '03-tasks.md'),
+      promptPath: join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+      spawnImpl,
+      resetImpl,
+      resolveHeadShaImpl: () => 'post-reset-sha',
+    });
+
+    expect(resetImpl).toHaveBeenCalledTimes(1);
+    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+    const pb = state.events.find(
+      (e: { type: string }) => e.type === 'pushback_dispatch'
+    );
+    expect(pb.payload.reset).toBe(true);
+  });
+
+  it('captures parse_error + raw_result_text when builder exit is malformed', async () => {
+    const malformed = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: 'not a structured exit at all',
+      stop_reason: 'end_turn',
+      session_id: 'pb-session-bad',
+      total_cost_usd: 0.5,
+      duration_ms: 1000,
+      num_turns: 5,
+    });
+    const spawnImpl = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: [malformed], exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await dispatchPushback({
+      taskId: 'T-99',
+      findingsPath,
+      cwd: workDir,
+      statePath,
+      taskListPath: join(specDir, '03-tasks.md'),
+      promptPath: join(workDir, 'scripts/harness/lib/prompts/builder.md'),
+      spawnImpl,
+      resolveHeadShaImpl: () => 'whatever',
+    });
+
+    expect(result.exit).toBeNull();
+    expect(result.parseError).toBeTruthy();
+
+    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+    const pb = state.events.find(
+      (e: { type: string }) => e.type === 'pushback_dispatch'
+    );
+    expect(pb.payload.parse_error).toBeTruthy();
+    expect(pb.payload.raw_result_text).toContain('not a structured exit');
+  });
+});

--- a/scripts/harness/lib/pushback-dispatch.ts
+++ b/scripts/harness/lib/pushback-dispatch.ts
@@ -1,0 +1,213 @@
+/**
+ * Operator pushback dispatcher.
+ *
+ * Closes finding #7 (round 37): when the cold-reader returns `approve` but the
+ * operator catches a divergence on review, today the only options are
+ * (a) operator-fix in a follow-up commit (defeats the orchestrator),
+ * (b) revert and re-dispatch fresh (likely reproduces the bug), or
+ * (c) reset, manually re-render the input, append findings, shell to
+ *     `claude -p` directly. (c) was the round-37/41 manual workaround that cost
+ * ~12 min of operator labor and wrote nothing to state.json.
+ *
+ * This module is the (c) path automated. The operator authors a findings
+ * markdown file, runs `harness pushback T-N --findings findings.md [--reset]`,
+ * and the dispatcher renders the standard builder input, appends the findings
+ * as an `## Operator pushback` section, dispatches the builder, and logs a
+ * `pushback_dispatch` event to state.json.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { buildBuilderInput, formatBuilderInputMarkdown } from './builder-input';
+import { parseTaskList } from './task-parser';
+import { dispatchSubagent, type DispatchResult } from './subagent-dispatch';
+import {
+  parseBuilderExit,
+  type BuilderExit,
+} from './dispatch/builder-dispatch';
+import { appendEvent, defaultStatePath } from './state-store';
+
+export interface PushbackDispatchOptions {
+  taskId: string;
+  findingsPath: string;
+  /** When true, run `git reset --hard HEAD~1` before dispatching the builder.
+   * Use to discard the previous orchestrator-driven commit so the builder has
+   * a clean tree to commit on top of. */
+  reset?: boolean;
+  /** Override task-list path. */
+  taskListPath?: string;
+  /** Override builder system prompt. */
+  promptPath?: string;
+  /** Working directory. */
+  cwd?: string;
+  /** Override state.json path. */
+  statePath?: string;
+  /** Test seams. */
+  spawnImpl?: typeof import('node:child_process').spawn;
+  resetImpl?: () => void;
+  resolveHeadShaImpl?: () => string;
+}
+
+export interface PushbackDispatchResult {
+  exit: BuilderExit | null;
+  raw: DispatchResult;
+  parseError?: string;
+  /** SHA produced by the pushback dispatch (resolved from HEAD post-build). */
+  commitSha?: string;
+  /** Path that was rendered + sent to the subagent (kept for debug). */
+  renderedInputPath?: string;
+}
+
+const DEFAULT_TASK_LIST = 'docs/specs/incident-capture/03-tasks.md';
+const DEFAULT_PROMPT = 'scripts/harness/lib/prompts/builder.md';
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+const DEFAULT_DISALLOWED_TOOLS = [
+  'Bash(firebase deploy:*)',
+  'Bash(vercel deploy:*)',
+  'Bash(vercel --prod:*)',
+  'Bash(gcloud:*)',
+  'Bash(kubectl apply:*)',
+  'Bash(terraform apply:*)',
+];
+
+export async function dispatchPushback(
+  opts: PushbackDispatchOptions
+): Promise<PushbackDispatchResult> {
+  const taskListPath = opts.taskListPath ?? DEFAULT_TASK_LIST;
+  const promptPath = opts.promptPath ?? DEFAULT_PROMPT;
+  const statePath = opts.statePath ?? defaultStatePath(opts.cwd);
+  const findingsPath = resolve(opts.cwd ?? process.cwd(), opts.findingsPath);
+
+  if (!existsSync(findingsPath)) {
+    throw new Error(
+      `pushback dispatch: findings file not found: ${findingsPath}`
+    );
+  }
+  const findingsBody = readFileSync(findingsPath, 'utf8');
+  if (!findingsBody.trim()) {
+    throw new Error(
+      `pushback dispatch: findings file is empty: ${findingsPath}`
+    );
+  }
+
+  if (opts.reset) {
+    const reset = opts.resetImpl ?? defaultReset(opts.cwd);
+    reset();
+  }
+
+  const taskListMd = readFileSync(taskListPath, 'utf8');
+  const systemPrompt = readFileSync(promptPath, 'utf8');
+  const featureDir = dirname(taskListPath);
+  const specMd = readFileSync(join(featureDir, '01-spec.md'), 'utf8');
+  const designMd = readFileSync(join(featureDir, '02-design.md'), 'utf8');
+
+  const parsed = parseTaskList(taskListMd);
+  const task = parsed.tasks.find((t) => t.id === opts.taskId);
+  if (!task) {
+    throw new Error(
+      `pushback dispatch: task ${opts.taskId} not found in ${taskListPath}`
+    );
+  }
+  const builderInput = buildBuilderInput({
+    task,
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+  });
+  const inputMd = formatBuilderInputMarkdown(builderInput);
+
+  const pushbackSection = buildPushbackSection(findingsBody);
+  const fullInput = `${inputMd}\n\n${pushbackSection}`;
+  const fullPrompt = `${systemPrompt}\n\n---\n\n${fullInput}`;
+
+  const raw = await dispatchSubagent({
+    prompt: fullPrompt,
+    model: 'sonnet',
+    permissionMode: 'bypassPermissions',
+    disallowedTools: DEFAULT_DISALLOWED_TOOLS,
+    cwd: opts.cwd,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    spawnImpl: opts.spawnImpl,
+  });
+
+  let exit: BuilderExit | null = null;
+  let parseError: string | undefined;
+  try {
+    exit = parseBuilderExit(raw.resultText);
+  } catch (err) {
+    parseError = err instanceof Error ? err.message : String(err);
+  }
+
+  // Resolve the actual HEAD post-dispatch (per finding #9, never trust the
+  // builder's reported commit_sha).
+  let commitSha: string | undefined;
+  try {
+    const resolveHead = opts.resolveHeadShaImpl ?? defaultResolveHead(opts.cwd);
+    commitSha = resolveHead();
+  } catch {
+    commitSha = undefined;
+  }
+
+  appendEvent(statePath, {
+    task_id: opts.taskId,
+    type: 'pushback_dispatch',
+    payload: {
+      role: 'builder',
+      cost_usd: raw.costUsd,
+      duration_ms: raw.durationMs,
+      num_turns: raw.numTurns,
+      session_id: raw.sessionId,
+      stop_reason: raw.stopReason,
+      findings_source: opts.findingsPath,
+      reset: opts.reset === true,
+      commit_sha: commitSha,
+      ...(exit && exit.status === 'success' ? { status: 'success' } : {}),
+      ...(parseError
+        ? { parse_error: parseError, raw_result_text: raw.resultText }
+        : {}),
+    },
+  });
+
+  return { exit, raw, parseError, commitSha };
+}
+
+/** Render the operator pushback section that gets appended to the standard
+ * builder input. Keep the format stable so the builder's prompt training
+ * sees the same shape every time. */
+export function buildPushbackSection(findingsBody: string): string {
+  return [
+    '---',
+    '',
+    '## Operator pushback re-dispatch',
+    '',
+    'An earlier dispatch shipped a commit that the operator (or cold-reader)',
+    'reviewed and rejected. The previous commit may already be reset (see the',
+    '`reset=true` flag on the harness invocation). Honor the spec verbatim,',
+    'addressing each finding below as a constraint on this re-dispatch:',
+    '',
+    findingsBody.trim(),
+  ].join('\n');
+}
+
+function defaultReset(cwd?: string): () => void {
+  return () => {
+    // Safety: refuse to reset if HEAD~1 doesn't exist (e.g., initial commit).
+    try {
+      execSync('git rev-parse HEAD~1', {
+        cwd,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+    } catch {
+      throw new Error(
+        'pushback dispatch: --reset requested but HEAD~1 does not exist (refusing to reset on an initial commit)'
+      );
+    }
+    execSync('git reset --hard HEAD~1', { cwd, stdio: 'inherit' });
+  };
+}
+
+function defaultResolveHead(cwd?: string): () => string {
+  return () => execSync('git rev-parse HEAD', { cwd, encoding: 'utf8' }).trim();
+}

--- a/scripts/harness/lib/state-store.ts
+++ b/scripts/harness/lib/state-store.ts
@@ -26,7 +26,8 @@ export type StateEventType =
   | 'dispatch_end'
   | 'amendment_applied'
   | 'amendment_apply_failed'
-  | 'cycle_halt';
+  | 'cycle_halt'
+  | 'pushback_dispatch';
 
 export interface StateEvent {
   ts: string; // ISO 8601


### PR DESCRIPTION
## Summary
PR-B / PR-3 of 3. Last of the bundle. Closes findings #7 + #11.

\`harness pushback T-N --findings findings.md [--reset]\` — automates the manual \`claude -p\` shell-out path used in rounds 37 + 41 when cold-reader returned approve but operator caught a divergence on review.

The dispatcher: validates findings file, optionally \`git reset --hard HEAD~1\`, renders the standard builder input, appends an "## Operator pushback re-dispatch" section with the findings body, dispatches the builder via existing subagent-dispatch wrapper, parses BuilderExit, resolves commit_sha from \`git rev-parse HEAD\` (per finding #9), and logs a \`pushback_dispatch\` event to state.json with cost/duration/sha + parse_error/raw_result_text on parse failure.

Operator labor per pushback: ~12 min → ~5 min (write findings to file + run command). Cost stays the same (~\$0.66 per re-dispatch).

Cites §11 (PR-B PR-3 of 3).

## Diff scope
- \`scripts/harness/lib/pushback-dispatch.ts\` (new, 211 LOC)
- \`scripts/harness/lib/pushback-dispatch.test.ts\` (new, 9 tests)
- \`scripts/harness/lib/state-store.ts\`: add \`pushback_dispatch\` to event type union
- \`scripts/harness/cli.ts\`: new \`case 'pushback'\` + \`runPushback()\` + usage update + new \`--findings\`/\`--reset\` flags

## Test plan
- [x] preflight green (1141 tests pass; 9 new in pushback-dispatch.test.ts)
- [x] CLI smoke: \`harness pushback\` (no args) prints usage; \`harness pushback T-99\` (no --findings) errors with usage
- [ ] Hand-test on next real pushback scenario (likely first slice-3 task that surfaces divergence)

## Sequencing
Lands last of the PR-B bundle. PR-1 unblocked the diagnostic surface; PR-2 should reduce pushback frequency; PR-3 makes residual pushbacks cheaper.

## After this merges
Slice-3 readiness gate (per §11 plan): dispatch \`harness orchestrate T-27\` to verify all three PR-B improvements work together (state.json contains real SHA + findings array, cold-reader sees task body + scope #7, pushback CLI available if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)