### PR TITLE
feat(incidents): T-27 ActivationPetPicker (slice-3 entry; PR-B integration test)

### DIFF
--- a/src/features/incidents/components/ActivationPetPicker.test.tsx
+++ b/src/features/incidents/components/ActivationPetPicker.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ActivationPetPicker } from './ActivationPetPicker';
+import { useIncidentStore, type IncidentState } from '@store/useIncidentStore';
+import { usePetsStore } from '@store/pets.store';
+import type { Pet } from '@features/pets/types';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-router-dom')>();
+  return { ...mod, useNavigate: () => mockNavigate };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@store/useIncidentStore');
+vi.mock('@store/pets.store');
+
+function makePet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    id: 'pet-1',
+    name: 'Buddy',
+    breed: 'Lab',
+    birthDate: new Date('2020-01-01'),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: 'user-1',
+    isArchived: false,
+    photos: [],
+    ...overrides,
+  };
+}
+
+function setupPets(pets: Pet[]) {
+  vi.mocked(usePetsStore).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: any) => (selector ? selector({ pets }) : { pets })
+  );
+}
+
+describe('ActivationPetPicker (BR-28, DQ-7)', () => {
+  const mockStartIncident = vi.fn().mockResolvedValue(undefined);
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIncidentStore).mockReturnValue({
+      startIncident: mockStartIncident,
+    } as unknown as IncidentState);
+    setupPets([]);
+  });
+
+  it('shows all user pets in the list', () => {
+    setupPets([
+      makePet({ id: 'pet-1', name: 'Buddy' }),
+      makePet({ id: 'pet-2', name: 'Luna' }),
+    ]);
+    render(<ActivationPetPicker open onClose={mockOnClose} />);
+
+    expect(screen.getByText('Buddy')).toBeInTheDocument();
+    expect(screen.getByText('Luna')).toBeInTheDocument();
+  });
+
+  it('tapping a pet calls startIncident with that petId and navigates to /incidents/active (AC-19)', async () => {
+    const user = userEvent.setup();
+    setupPets([makePet({ id: 'pet-42', name: 'Rex' })]);
+
+    render(<ActivationPetPicker open onClose={mockOnClose} />);
+    await user.click(screen.getByRole('button', { name: /Rex/ }));
+
+    expect(mockStartIncident).toHaveBeenCalledWith({ petId: 'pet-42' });
+    expect(mockNavigate).toHaveBeenCalledWith('/incidents/active');
+  });
+
+  // Pushback fix: ListItemAvatar is unconditional — both photo and no-photo pets
+  // must render with consistent layout/spacing (never absent from DOM).
+  it('renders Avatar with photo URL for pet with mainPhotoUrl', () => {
+    setupPets([
+      makePet({
+        id: 'pet-1',
+        name: 'Buddy',
+        mainPhotoUrl: 'https://example.com/buddy.jpg',
+      }),
+    ]);
+    render(<ActivationPetPicker open onClose={mockOnClose} />);
+
+    const img = screen.getByRole('img', { name: 'Buddy' });
+    expect(img).toHaveAttribute('src', 'https://example.com/buddy.jpg');
+  });
+
+  it('renders Avatar with first-letter fallback for pet without mainPhotoUrl (ListItemAvatar still present)', () => {
+    setupPets([makePet({ id: 'pet-2', name: 'Luna' })]);
+
+    render(<ActivationPetPicker open onClose={mockOnClose} />);
+
+    expect(screen.getByText('L')).toBeInTheDocument();
+    // Button is still rendered — ListItemAvatar occupies its layout slot
+    expect(screen.getByRole('button', { name: /Luna/ })).toBeInTheDocument();
+  });
+});

--- a/src/features/incidents/components/ActivationPetPicker.tsx
+++ b/src/features/incidents/components/ActivationPetPicker.tsx
@@ -1,0 +1,67 @@
+import {
+  Avatar,
+  Box,
+  Drawer,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { usePetsStore } from '@store/pets.store';
+import { useIncidentStore } from '@store/useIncidentStore';
+
+// BR-28 (multi-pet rule), BR-1 (≤2 taps), NFR-3 (one-thumb); DQ-7 (bottom Drawer).
+// Tapping a pet IS the activation: calls startIncident synchronously then navigates.
+
+interface ActivationPetPickerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ActivationPetPicker({
+  open,
+  onClose,
+}: ActivationPetPickerProps) {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const pets = usePetsStore((s) => s.pets);
+  const { startIncident } = useIncidentStore();
+
+  const handleSelect = (petId: string) => {
+    onClose();
+    void startIncident({ petId });
+    navigate('/incidents/active');
+  };
+
+  return (
+    <Drawer anchor="bottom" open={open} onClose={onClose}>
+      <Box sx={{ p: 2, pb: 0 }}>
+        <Typography variant="h6">{t('incidents.petPickerTitle')}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t('incidents.petPickerHelp')}
+        </Typography>
+      </Box>
+      <List>
+        {pets.map((pet) => (
+          <ListItem disablePadding key={pet.id}>
+            <ListItemButton
+              onClick={() => handleSelect(pet.id)}
+              sx={{ minHeight: 44 }}
+            >
+              <ListItemAvatar>
+                <Avatar src={pet.mainPhotoUrl || undefined} alt={pet.name}>
+                  {pet.name[0]?.toUpperCase()}
+                </Avatar>
+              </ListItemAvatar>
+              <ListItemText primary={pet.name} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## Summary
T-27 (ActivationPetPicker) — slice-3 entry. Bottom Drawer with pet list per design §D5 DQ-7. Tap a pet calls \`startIncident({ petId })\` and navigates per BR-28.

**This task was the slice-3 readiness gate** for PR-B. All three improvements validated end-to-end in production:

- ✅ **Finding #9** — state.json captured real SHA \`b91d895\` (and later \`695e81c\`) from \`git rev-parse HEAD\` instead of builder's reported value
- ✅ **Finding #10** — both cold-reader veto events captured \`FULL_FINDINGS_PRESENT\` (no re-dispatch needed to read finding text)
- ✅ **Finding #6** — cold-reader scope #7 caught the divergence twice (orchestrator → arbiter → re-builder cycle)
- ✅ **Finding #7 (PR-B-3)** — \`harness pushback T-27 --findings <path> --reset\` recovered cleanly when arbiter said \`pushback\`

## Trajectory
| Step | Cost | Outcome |
|---|---|---|
| Orchestrator: builder #1 | \$1.25 | success commit \`b91d895\` |
| Cold-reader #1 | \$0.17 | veto, 1 finding |
| Arbiter #1 | \$0.27 | \`amend_task\` |
| (amendment_applied) | — | applied to 03-tasks.md |
| Builder #2 | \$0.37 | success |
| Cold-reader #2 | \$0.15 | veto, 1 finding |
| Arbiter #2 | \$0.20 | \`pushback\` (no further amendment needed) |
| **Orchestrator halt** (v1 doesn't auto-loop pushback) | (subtotal \$2.42) | halt_pushback_unsupported |
| **Manual: \`harness pushback T-27 --findings t27-pushback-findings.md --reset\`** | \$1.15 | **success commit \`695e81c\`** |
| **Total round 43** | **\$3.57** | shipped |

## What the divergence was
Builder shipped \`{pet.mainPhotoUrl && <ListItemAvatar>...}\` — conditional avatar rendering that omits the entire avatar slot when a pet has no photo, creating inconsistent layout. Arbiter's pushback: use MUI Avatar's children-as-fallback (\`<Avatar src={url || undefined}>{name[0]}</Avatar>\`).

## Harness lessons (one new finding)
**Finding #14: \`harness pushback --reset\` should refuse if HEAD's commit isn't a builder-shipped task commit.** When operator runs \`pushback --reset\` on a fresh branch off main (e.g., for the orchestrator's halted run, where the operator might create a new branch), HEAD~1 is whatever was last on main — not a builder commit for this task. \`reset --hard HEAD~1\` then clobbers an unrelated merged PR. Fix: validate HEAD's commit message matches the task ID before resetting; otherwise refuse and surface the operator's intent for confirmation. Worked around in this PR by \`git rebase main\` post-push.

## Test plan
- [x] preflight green
- [x] AC-19 covered (multi-pet picker tested)
- [x] Manual pushback CLI smoke (this PR)
- [ ] After merge: T-28 next slice-3 task

🤖 Generated with [Claude Code](https://claude.com/claude-code)