### PR TITLE
feat(harness): observability bundle — dispatches.jsonl + stats + watch (Axes 4+5)

### DIFF
--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -47,6 +47,17 @@ import {
   summarizeOrchestrateResult,
 } from './lib/orchestrate.ts';
 import { dispatchPushback } from './lib/pushback-dispatch.ts';
+import {
+  defaultDispatchesLogPath,
+  loadDispatchesLog,
+} from './lib/dispatches-log.ts';
+import {
+  computeStats,
+  formatStatsHuman,
+  type StatsFilters,
+} from './lib/stats.ts';
+import { defaultStatePath } from './lib/state-store.ts';
+import { watchState } from './lib/watch.ts';
 import { dirname, join } from 'node:path';
 import { execSync } from 'node:child_process';
 
@@ -90,6 +101,15 @@ function usage(): string {
     '                             --reset to first `git reset --hard HEAD~1`',
     '                             (discards the previous orchestrator commit).',
     '                             Logs a pushback_dispatch event to state.json.',
+    '  stats                      Aggregate stats from .harness/dispatches.jsonl:',
+    '                             per-role cost histogram, verdict distribution,',
+    '                             per-task rollup, recent dispatches. Use --task,',
+    '                             --role, --since to filter.',
+    '  watch                      Tail .harness/state.json and pretty-print',
+    '                             orchestrator events as they appear. Exits on',
+    '                             orchestrate_end or Ctrl+C. Use --state to',
+    '                             override the watched path; --no-color disables',
+    '                             ANSI codes.',
     '',
     'Options:',
     `  --file <path>              Task list to read (default: ${DEFAULT_TASK_FILE}).`,
@@ -101,6 +121,11 @@ function usage(): string {
     '                             for review.',
     '  --findings <path>          For pushback: markdown file with operator findings.',
     '  --reset                    For pushback: `git reset --hard HEAD~1` first.',
+    '  --task <id>                For stats: filter by task id (e.g. T-22).',
+    '  --role <r>                 For stats: filter by role (builder|cold-reader|arbiter|pushback).',
+    '  --since <iso>              For stats: only entries with ts >= ISO datetime.',
+    '  --state <path>             For watch: state.json path (default `.harness/state.json`).',
+    '  --no-color                 For watch: disable ANSI color codes.',
     '  -h, --help                 Show this help.',
   ].join('\n');
 }
@@ -234,6 +259,11 @@ function main(): void {
       diff: { type: 'string' },
       findings: { type: 'string' },
       reset: { type: 'boolean', default: false },
+      task: { type: 'string' },
+      role: { type: 'string' },
+      since: { type: 'string' },
+      state: { type: 'string' },
+      'no-color': { type: 'boolean', default: false },
     },
     allowPositionals: true,
   });
@@ -598,6 +628,22 @@ function main(): void {
       });
       break;
     }
+    case 'stats': {
+      void runStats(values.task, values.role, values.since, values.json).catch(
+        (err) => {
+          const reason = err instanceof Error ? err.message : String(err);
+          fail(`stats failed: ${reason}`);
+        }
+      );
+      break;
+    }
+    case 'watch': {
+      void runWatch(values.state, values['no-color'] === true).catch((err) => {
+        const reason = err instanceof Error ? err.message : String(err);
+        fail(`watch failed: ${reason}`);
+      });
+      break;
+    }
     default:
       fail(`unknown command '${command}'\n\n${usage()}`);
   }
@@ -891,6 +937,59 @@ async function runPushback(
     process.stdout.write(`state log: .harness/state.json\n`);
   }
   process.exit(result.exit?.status === 'success' ? 0 : 2);
+}
+
+async function runStats(
+  taskId: string | undefined,
+  role: string | undefined,
+  since: string | undefined,
+  json: boolean
+): Promise<void> {
+  const logPath = defaultDispatchesLogPath();
+  const entries = loadDispatchesLog(logPath);
+  if (entries.length === 0) {
+    process.stderr.write(
+      `harness: no dispatches logged at ${logPath}. Run \`harness orchestrate T-N\` first.\n`
+    );
+    process.exit(2);
+  }
+  const filters: StatsFilters = {};
+  if (taskId) filters.taskId = taskId;
+  if (role) {
+    if (
+      role !== 'builder' &&
+      role !== 'cold-reader' &&
+      role !== 'arbiter' &&
+      role !== 'pushback'
+    ) {
+      fail(
+        `--role must be one of: builder, cold-reader, arbiter, pushback (got ${role})`
+      );
+    }
+    filters.role = role;
+  }
+  if (since) filters.since = since;
+  const report = computeStats(entries, filters);
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatStatsHuman(report)}\n`);
+  }
+  process.exit(0);
+}
+
+async function runWatch(
+  statePath: string | undefined,
+  noColor: boolean
+): Promise<void> {
+  const path = statePath
+    ? resolve(process.cwd(), statePath)
+    : defaultStatePath();
+  process.stderr.write(
+    `harness: watching ${path} (Ctrl+C to stop; auto-exits on orchestrate_end)\n`
+  );
+  await watchState({ statePath: path, noColor });
+  process.exit(0);
 }
 
 main();

--- a/scripts/harness/lib/dispatches-log.test.ts
+++ b/scripts/harness/lib/dispatches-log.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendDispatch,
+  loadDispatchesLog,
+  type DispatchLogEntry,
+} from './dispatches-log';
+
+let workDir: string;
+let logPath: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'dispatches-log-'));
+  logPath = join(workDir, '.harness/dispatches.jsonl');
+});
+
+function makeEntry(over: Partial<DispatchLogEntry> = {}): DispatchLogEntry {
+  return {
+    ts: '2026-05-03T20:00:00.000Z',
+    run_id: 'T-99-1',
+    task_id: 'T-99',
+    role: 'builder',
+    cost_usd: 0.5,
+    duration_ms: 60_000,
+    num_turns: 5,
+    session_id: 'session-1',
+    stop_reason: 'end_turn',
+    status: 'success',
+    commit_sha: 'abc123',
+    ...over,
+  };
+}
+
+describe('appendDispatch', () => {
+  it('creates the directory and writes one line per entry', () => {
+    appendDispatch(logPath, makeEntry());
+    appendDispatch(logPath, makeEntry({ task_id: 'T-100' }));
+
+    const raw = readFileSync(logPath, 'utf8');
+    expect(raw.split('\n').filter((l) => l.length > 0)).toHaveLength(2);
+  });
+
+  it('round-trips an entry through loadDispatchesLog', () => {
+    const entry = makeEntry({
+      role: 'cold-reader',
+      verdict: 'veto',
+      findings_count: 2,
+    });
+    appendDispatch(logPath, entry);
+
+    const loaded = loadDispatchesLog(logPath);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toEqual(entry);
+  });
+});
+
+describe('loadDispatchesLog', () => {
+  it('returns empty array when the log file does not exist', () => {
+    expect(loadDispatchesLog(logPath)).toEqual([]);
+  });
+
+  it('skips malformed lines silently', () => {
+    appendDispatch(logPath, makeEntry());
+    // Append a corrupt line (e.g., a half-written entry from a crash).
+    writeFileSync(
+      logPath,
+      readFileSync(logPath, 'utf8') + 'not-json\n',
+      'utf8'
+    );
+    appendDispatch(logPath, makeEntry({ task_id: 'T-100' }));
+
+    const loaded = loadDispatchesLog(logPath);
+    // Two valid entries; the malformed line in the middle is silently skipped.
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0]?.task_id).toBe('T-99');
+    expect(loaded[1]?.task_id).toBe('T-100');
+  });
+});

--- a/scripts/harness/lib/dispatches-log.ts
+++ b/scripts/harness/lib/dispatches-log.ts
@@ -1,0 +1,97 @@
+/**
+ * Long-term dispatch log (Axis 5 — round 43).
+ *
+ * Per-run state lives in `.harness/state.json` (or the per-run namespaced
+ * variant). That file is loaded-and-rewritten on every appendEvent — fine
+ * for current-run audit but it's not durable across many runs.
+ *
+ * `.harness/dispatches.jsonl` is the long-term store: one line per
+ * dispatch_end (or pushback_dispatch) event, append-only, never overwritten.
+ * Spans every run, every task, the lifetime of the project. Easy to grep,
+ * easy to aggregate in `harness stats`.
+ *
+ * Schema is intentionally a SUPERSET of `dispatch_end` payload — every field
+ * the orchestrator already records is preserved, plus run_id + ts + task_id
+ * so each line is self-describing without needing context from the
+ * surrounding state.json.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+export interface DispatchLogEntry {
+  /** ISO 8601 timestamp when the dispatch ended. */
+  ts: string;
+  /** Run identifier from state.json (e.g. "T-14-1714329000000"). */
+  run_id: string;
+  /** Task identifier (e.g. "T-14"). */
+  task_id: string;
+  /** Role of the agent that ran. */
+  role: 'builder' | 'cold-reader' | 'arbiter' | 'pushback';
+  /** Cost of the dispatch in USD (subscription-quota equivalent). */
+  cost_usd: number;
+  /** Wall-clock duration in milliseconds. */
+  duration_ms: number;
+  /** Conversational turns the agent took. */
+  num_turns: number;
+  /** Session id from claude -p envelope. */
+  session_id: string;
+  /** Stop reason (end_turn, max_turns, etc.). */
+  stop_reason: string;
+  /** Builder-only: structured-exit status. */
+  status?: 'success' | 'spec_gap' | 'verify_fail' | 'budget_exceeded';
+  /** Cold-reader-only: verdict. */
+  verdict?:
+    | 'approve'
+    | 'veto'
+    | 'amend_spec'
+    | 'amend_design'
+    | 'amend_task'
+    | 'pushback';
+  /** Cold-reader-only: number of structured findings. */
+  findings_count?: number;
+  /** Cold-reader-only: structured findings array (per finding #10). */
+  findings?: unknown[];
+  /** Builder-only: commit SHA produced (always derived from `git rev-parse HEAD` per finding #9). */
+  commit_sha?: string;
+  /** When >1 dispatch of the same role for the same task in the same run. */
+  attempt?: number;
+  /** When the structured exit failed to parse. */
+  parse_error?: string;
+}
+
+export function defaultDispatchesLogPath(cwd?: string): string {
+  return resolve(cwd ?? process.cwd(), '.harness/dispatches.jsonl');
+}
+
+/**
+ * Append one dispatch entry to the JSONL log. Atomic per-line write (one
+ * appendFileSync == one entry == one filesystem operation, no partial-line
+ * risk under reasonable load).
+ */
+export function appendDispatch(path: string, entry: DispatchLogEntry): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  appendFileSync(path, `${JSON.stringify(entry)}\n`, 'utf8');
+}
+
+/**
+ * Read the full log. Skips malformed lines silently (the log is append-only
+ * but partial writes during an interrupt could leave a fragment; one bad
+ * line shouldn't poison `harness stats`).
+ */
+export function loadDispatchesLog(path: string): DispatchLogEntry[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, 'utf8');
+  const out: DispatchLogEntry[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed) as DispatchLogEntry);
+    } catch {
+      // Skip malformed line.
+    }
+  }
+  return out;
+}

--- a/scripts/harness/lib/state-store.ts
+++ b/scripts/harness/lib/state-store.ts
@@ -18,6 +18,11 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import {
+  appendDispatch,
+  defaultDispatchesLogPath,
+  type DispatchLogEntry,
+} from './dispatches-log';
 
 export type StateEventType =
   | 'orchestrate_start'
@@ -66,23 +71,112 @@ export function initState(taskId: string, path: string): OrchestratorState {
   return state;
 }
 
+export interface AppendEventOptions {
+  /** Override path for the long-term JSONL dispatches log (Axis 5).
+   * Defaults to `.harness/dispatches.jsonl` in the same directory tree as
+   * the state.json. Pass `null` to disable the dual-write entirely
+   * (intended for tests or for opting out of the long-term log). */
+  dispatchesLogPath?: string | null;
+}
+
 export function appendEvent(
   path: string,
-  event: Omit<StateEvent, 'ts'> & { ts?: string }
+  event: Omit<StateEvent, 'ts'> & { ts?: string },
+  opts: AppendEventOptions = {}
 ): OrchestratorState {
   const state = loadState(path) ?? {
     run_id: `${event.task_id}-${Date.now()}`,
     started_at: new Date().toISOString(),
     events: [],
   };
+  const ts = event.ts ?? new Date().toISOString();
   state.events.push({
-    ts: event.ts ?? new Date().toISOString(),
+    ts,
     task_id: event.task_id,
     type: event.type,
     payload: event.payload,
   });
   writeStateAtomic(path, state);
+
+  // Per Axis 5 (round 43): every dispatch_end / pushback_dispatch ALSO
+  // appends a self-describing line to the long-term JSONL log. Append-only,
+  // never overwritten — survives across orchestrate runs and across tasks.
+  if (event.type === 'dispatch_end' || event.type === 'pushback_dispatch') {
+    if (opts.dispatchesLogPath !== null) {
+      const logPath =
+        opts.dispatchesLogPath ?? defaultDispatchesLogPath(dirname(path));
+      const entry = buildDispatchLogEntry(
+        state.run_id,
+        event.task_id,
+        ts,
+        event.payload
+      );
+      if (entry) appendDispatch(logPath, entry);
+    }
+  }
+
   return state;
+}
+
+/**
+ * Project the state-event payload (which is `Record<string, unknown>` —
+ * caller-shaped) onto the typed DispatchLogEntry shape. Defensive: returns
+ * null if the payload doesn't have the minimum fields a dispatch entry
+ * needs (cost_usd + role). This lets callers append non-dispatch events
+ * to state.json without poisoning the long-term log.
+ */
+function buildDispatchLogEntry(
+  runId: string,
+  taskId: string,
+  ts: string,
+  payload: Record<string, unknown>
+): DispatchLogEntry | null {
+  const role = payload.role;
+  const cost = payload.cost_usd;
+  if (typeof role !== 'string' || typeof cost !== 'number') return null;
+  if (
+    role !== 'builder' &&
+    role !== 'cold-reader' &&
+    role !== 'arbiter' &&
+    role !== 'pushback'
+  ) {
+    return null;
+  }
+  return {
+    ts,
+    run_id: runId,
+    task_id: taskId,
+    role,
+    cost_usd: cost,
+    duration_ms:
+      typeof payload.duration_ms === 'number' ? payload.duration_ms : 0,
+    num_turns: typeof payload.num_turns === 'number' ? payload.num_turns : 0,
+    session_id:
+      typeof payload.session_id === 'string' ? payload.session_id : '',
+    stop_reason:
+      typeof payload.stop_reason === 'string' ? payload.stop_reason : '',
+    ...(typeof payload.status === 'string'
+      ? { status: payload.status as DispatchLogEntry['status'] }
+      : {}),
+    ...(typeof payload.verdict === 'string'
+      ? { verdict: payload.verdict as DispatchLogEntry['verdict'] }
+      : {}),
+    ...(typeof payload.findings_count === 'number'
+      ? { findings_count: payload.findings_count }
+      : {}),
+    ...(Array.isArray(payload.findings)
+      ? { findings: payload.findings as unknown[] }
+      : {}),
+    ...(typeof payload.commit_sha === 'string'
+      ? { commit_sha: payload.commit_sha }
+      : {}),
+    ...(typeof payload.attempt === 'number'
+      ? { attempt: payload.attempt }
+      : {}),
+    ...(typeof payload.parse_error === 'string'
+      ? { parse_error: payload.parse_error }
+      : {}),
+  };
 }
 
 export function summarizeRun(state: OrchestratorState): {

--- a/scripts/harness/lib/stats.test.ts
+++ b/scripts/harness/lib/stats.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { computeStats, formatStatsHuman } from './stats';
+import type { DispatchLogEntry } from './dispatches-log';
+
+function entry(over: Partial<DispatchLogEntry>): DispatchLogEntry {
+  return {
+    ts: '2026-05-03T20:00:00.000Z',
+    run_id: 'r1',
+    task_id: 'T-99',
+    role: 'builder',
+    cost_usd: 0,
+    duration_ms: 0,
+    num_turns: 1,
+    session_id: 's1',
+    stop_reason: 'end_turn',
+    ...over,
+  };
+}
+
+describe('computeStats — empty + basic', () => {
+  it('returns zeros for an empty log', () => {
+    const r = computeStats([]);
+    expect(r.overall.totalDispatches).toBe(0);
+    expect(r.overall.totalCostUsd).toBe(0);
+    expect(r.byRole).toEqual([]);
+    expect(r.recent).toEqual([]);
+  });
+
+  it('aggregates counts, cost, duration across all roles', () => {
+    const r = computeStats([
+      entry({
+        role: 'builder',
+        cost_usd: 1.0,
+        duration_ms: 60_000,
+        status: 'success',
+      }),
+      entry({
+        role: 'builder',
+        cost_usd: 0.5,
+        duration_ms: 30_000,
+        status: 'verify_fail',
+      }),
+      entry({
+        role: 'cold-reader',
+        cost_usd: 0.27,
+        duration_ms: 10_000,
+        verdict: 'approve',
+      }),
+    ]);
+    expect(r.overall.totalDispatches).toBe(3);
+    expect(r.overall.totalCostUsd).toBeCloseTo(1.77);
+    expect(r.byRole).toHaveLength(2);
+
+    const builder = r.byRole.find((x) => x.role === 'builder')!;
+    expect(builder.count).toBe(2);
+    expect(builder.totalCostUsd).toBeCloseTo(1.5);
+    expect(builder.avgCostUsd).toBeCloseTo(0.75);
+    expect(builder.minCostUsd).toBe(0.5);
+    expect(builder.maxCostUsd).toBe(1.0);
+    expect(builder.outcomes).toEqual({ success: 1, verify_fail: 1 });
+    expect(builder.successRate).toBe(0.5);
+
+    const coldReader = r.byRole.find((x) => x.role === 'cold-reader')!;
+    expect(coldReader.vetoRate).toBe(0);
+  });
+});
+
+describe('computeStats — veto rate and pushback success rate', () => {
+  it('cold-reader veto rate', () => {
+    const r = computeStats([
+      entry({ role: 'cold-reader', cost_usd: 0.2, verdict: 'veto' }),
+      entry({ role: 'cold-reader', cost_usd: 0.2, verdict: 'veto' }),
+      entry({ role: 'cold-reader', cost_usd: 0.2, verdict: 'approve' }),
+    ]);
+    const cr = r.byRole.find((x) => x.role === 'cold-reader')!;
+    expect(cr.vetoRate).toBeCloseTo(2 / 3);
+  });
+
+  it('pushback success rate', () => {
+    const r = computeStats([
+      entry({ role: 'pushback', cost_usd: 0.7, status: 'success' }),
+      entry({ role: 'pushback', cost_usd: 0.7, status: 'success' }),
+      entry({ role: 'pushback', cost_usd: 0.7, status: 'verify_fail' }),
+    ]);
+    const pb = r.byRole.find((x) => x.role === 'pushback')!;
+    expect(pb.successRate).toBeCloseTo(2 / 3);
+  });
+});
+
+describe('computeStats — filters', () => {
+  const fixture = [
+    entry({
+      task_id: 'T-1',
+      role: 'builder',
+      cost_usd: 1,
+      ts: '2026-05-01T00:00:00Z',
+    }),
+    entry({
+      task_id: 'T-2',
+      role: 'builder',
+      cost_usd: 2,
+      ts: '2026-05-02T00:00:00Z',
+    }),
+    entry({
+      task_id: 'T-2',
+      role: 'cold-reader',
+      cost_usd: 0.3,
+      ts: '2026-05-02T00:01:00Z',
+      verdict: 'approve',
+    }),
+  ];
+
+  it('filters by task_id', () => {
+    const r = computeStats(fixture, { taskId: 'T-2' });
+    expect(r.overall.totalDispatches).toBe(2);
+    expect(r.overall.totalCostUsd).toBeCloseTo(2.3);
+  });
+
+  it('filters by role', () => {
+    const r = computeStats(fixture, { role: 'cold-reader' });
+    expect(r.overall.totalDispatches).toBe(1);
+  });
+
+  it('filters by since', () => {
+    const r = computeStats(fixture, { since: '2026-05-02T00:00:00Z' });
+    expect(r.overall.totalDispatches).toBe(2);
+  });
+});
+
+describe('computeStats — recent + byTask', () => {
+  it('recent is sorted newest-first', () => {
+    const r = computeStats(
+      [
+        entry({ ts: '2026-05-01T00:00:00Z', task_id: 'T-1' }),
+        entry({ ts: '2026-05-03T00:00:00Z', task_id: 'T-3' }),
+        entry({ ts: '2026-05-02T00:00:00Z', task_id: 'T-2' }),
+      ],
+      { recentLimit: 2 }
+    );
+    expect(r.recent.map((e) => e.task_id)).toEqual(['T-3', 'T-2']);
+  });
+
+  it('byTask groups dispatches and runs', () => {
+    const r = computeStats([
+      entry({ task_id: 'T-1', run_id: 'r1', cost_usd: 1 }),
+      entry({ task_id: 'T-1', run_id: 'r2', cost_usd: 0.5 }),
+      entry({ task_id: 'T-2', run_id: 'r3', cost_usd: 0.3 }),
+    ]);
+    const t1 = r.byTask!.find((t) => t.task_id === 'T-1')!;
+    expect(t1.dispatches).toBe(2);
+    expect(t1.totalCostUsd).toBeCloseTo(1.5);
+    expect(t1.runIds.sort()).toEqual(['r1', 'r2']);
+  });
+
+  it('omits byTask when filtering to a single task', () => {
+    const r = computeStats([entry({ task_id: 'T-1' })], { taskId: 'T-1' });
+    expect(r.byTask).toBeUndefined();
+  });
+});
+
+describe('formatStatsHuman', () => {
+  it('renders a human-readable summary', () => {
+    const r = computeStats([
+      entry({
+        role: 'builder',
+        cost_usd: 1,
+        duration_ms: 60_000,
+        status: 'success',
+      }),
+      entry({
+        role: 'cold-reader',
+        cost_usd: 0.3,
+        duration_ms: 10_000,
+        verdict: 'approve',
+      }),
+    ]);
+    const text = formatStatsHuman(r);
+    expect(text).toMatch(/Harness dispatch stats/);
+    expect(text).toMatch(/builder/);
+    expect(text).toMatch(/cold-reader/);
+    expect(text).toMatch(/success rate/);
+    expect(text).toMatch(/veto rate: 0\.0%/);
+  });
+});

--- a/scripts/harness/lib/stats.ts
+++ b/scripts/harness/lib/stats.ts
@@ -1,0 +1,226 @@
+/**
+ * Aggregate stats over the long-term dispatches log (Axis 5 — round 43).
+ *
+ * Pure functions over `DispatchLogEntry[]`. The CLI wrapper handles loading
+ * the JSONL file and rendering. Useful as a library too — call directly
+ * for ad-hoc analysis from a REPL or another script.
+ */
+
+import type { DispatchLogEntry } from './dispatches-log';
+
+export interface RoleStats {
+  role: DispatchLogEntry['role'];
+  count: number;
+  totalCostUsd: number;
+  avgCostUsd: number;
+  minCostUsd: number;
+  maxCostUsd: number;
+  totalDurationMs: number;
+  avgDurationMs: number;
+  /** For each verdict/status seen, count. */
+  outcomes: Record<string, number>;
+  /** Cold-reader: # of vetoes / # of total cold-reader dispatches. */
+  vetoRate?: number;
+  /** Builder: # of (success | spec_gap | verify_fail | budget_exceeded) / total. */
+  successRate?: number;
+}
+
+export interface OverallStats {
+  totalDispatches: number;
+  totalCostUsd: number;
+  totalDurationMs: number;
+  parseErrorCount: number;
+  /** Distinct task_ids seen. */
+  uniqueTasks: number;
+  /** Distinct run_ids seen. */
+  uniqueRuns: number;
+}
+
+export interface StatsReport {
+  overall: OverallStats;
+  byRole: RoleStats[];
+  /** Optional task-level rollup when filtering by task. */
+  byTask?: Array<{
+    task_id: string;
+    dispatches: number;
+    totalCostUsd: number;
+    runIds: string[];
+  }>;
+  /** N most recent entries (for "what just happened" queries). */
+  recent: DispatchLogEntry[];
+}
+
+export interface StatsFilters {
+  /** Filter by exact task_id (e.g., "T-22"). */
+  taskId?: string;
+  /** Filter by role. */
+  role?: DispatchLogEntry['role'];
+  /** Inclusive lower bound on ts (ISO string). */
+  since?: string;
+  /** How many recent entries to surface. */
+  recentLimit?: number;
+}
+
+export function computeStats(
+  entries: DispatchLogEntry[],
+  filters: StatsFilters = {}
+): StatsReport {
+  const filtered = applyFilters(entries, filters);
+
+  const overall: OverallStats = {
+    totalDispatches: filtered.length,
+    totalCostUsd: sum(filtered.map((e) => e.cost_usd)),
+    totalDurationMs: sum(filtered.map((e) => e.duration_ms)),
+    parseErrorCount: filtered.filter((e) => e.parse_error).length,
+    uniqueTasks: new Set(filtered.map((e) => e.task_id)).size,
+    uniqueRuns: new Set(filtered.map((e) => e.run_id)).size,
+  };
+
+  const roles: DispatchLogEntry['role'][] = [
+    'builder',
+    'cold-reader',
+    'arbiter',
+    'pushback',
+  ];
+  const byRole: RoleStats[] = [];
+  for (const role of roles) {
+    const xs = filtered.filter((e) => e.role === role);
+    if (xs.length === 0) continue;
+    const costs = xs.map((e) => e.cost_usd);
+    const durations = xs.map((e) => e.duration_ms);
+    const outcomes: Record<string, number> = {};
+    for (const e of xs) {
+      const key = e.verdict ?? e.status ?? 'unknown';
+      outcomes[key] = (outcomes[key] ?? 0) + 1;
+    }
+    const stats: RoleStats = {
+      role,
+      count: xs.length,
+      totalCostUsd: sum(costs),
+      avgCostUsd: sum(costs) / xs.length,
+      minCostUsd: Math.min(...costs),
+      maxCostUsd: Math.max(...costs),
+      totalDurationMs: sum(durations),
+      avgDurationMs: sum(durations) / xs.length,
+      outcomes,
+    };
+    if (role === 'cold-reader') {
+      const vetoes = xs.filter((e) => e.verdict === 'veto').length;
+      stats.vetoRate = vetoes / xs.length;
+    }
+    if (role === 'builder' || role === 'pushback') {
+      const successes = xs.filter((e) => e.status === 'success').length;
+      stats.successRate = successes / xs.length;
+    }
+    byRole.push(stats);
+  }
+
+  let byTask: StatsReport['byTask'];
+  if (!filters.taskId) {
+    const taskMap = new Map<
+      string,
+      { dispatches: number; cost: number; runs: Set<string> }
+    >();
+    for (const e of filtered) {
+      const cur = taskMap.get(e.task_id) ?? {
+        dispatches: 0,
+        cost: 0,
+        runs: new Set<string>(),
+      };
+      cur.dispatches += 1;
+      cur.cost += e.cost_usd;
+      cur.runs.add(e.run_id);
+      taskMap.set(e.task_id, cur);
+    }
+    byTask = Array.from(taskMap.entries())
+      .map(([task_id, v]) => ({
+        task_id,
+        dispatches: v.dispatches,
+        totalCostUsd: v.cost,
+        runIds: Array.from(v.runs),
+      }))
+      .sort((a, b) => a.task_id.localeCompare(b.task_id));
+  }
+
+  const recent = [...filtered]
+    .sort((a, b) => (a.ts < b.ts ? 1 : -1))
+    .slice(0, filters.recentLimit ?? 10);
+
+  return { overall, byRole, byTask, recent };
+}
+
+function applyFilters(
+  entries: DispatchLogEntry[],
+  filters: StatsFilters
+): DispatchLogEntry[] {
+  return entries.filter((e) => {
+    if (filters.taskId && e.task_id !== filters.taskId) return false;
+    if (filters.role && e.role !== filters.role) return false;
+    if (filters.since && e.ts < filters.since) return false;
+    return true;
+  });
+}
+
+function sum(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0);
+}
+
+export function formatStatsHuman(report: StatsReport): string {
+  const out: string[] = [];
+  const o = report.overall;
+  out.push('Harness dispatch stats');
+  out.push(
+    `  Dispatches: ${o.totalDispatches}   Tasks: ${o.uniqueTasks}   Runs: ${o.uniqueRuns}   Parse errors: ${o.parseErrorCount}`
+  );
+  out.push(
+    `  Total cost: $${o.totalCostUsd.toFixed(4)}   Total duration: ${formatDuration(o.totalDurationMs)}`
+  );
+  out.push('');
+  out.push('Per role:');
+  for (const r of report.byRole) {
+    out.push(`  ${r.role.padEnd(12)} ×${r.count}`);
+    out.push(
+      `    cost  total $${r.totalCostUsd.toFixed(4)}  avg $${r.avgCostUsd.toFixed(4)}  min $${r.minCostUsd.toFixed(4)}  max $${r.maxCostUsd.toFixed(4)}`
+    );
+    out.push(
+      `    time  total ${formatDuration(r.totalDurationMs)}  avg ${formatDuration(r.avgDurationMs)}`
+    );
+    const outcomeStr = Object.entries(r.outcomes)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('  ');
+    if (outcomeStr) out.push(`    outcomes: ${outcomeStr}`);
+    if (r.vetoRate !== undefined) {
+      out.push(`    veto rate: ${(r.vetoRate * 100).toFixed(1)}%`);
+    }
+    if (r.successRate !== undefined) {
+      out.push(`    success rate: ${(r.successRate * 100).toFixed(1)}%`);
+    }
+  }
+  if (report.byTask && report.byTask.length > 0) {
+    out.push('');
+    out.push('Per task:');
+    for (const t of report.byTask) {
+      out.push(
+        `  ${t.task_id.padEnd(8)} ×${t.dispatches} dispatches across ${t.runIds.length} run(s)  $${t.totalCostUsd.toFixed(4)}`
+      );
+    }
+  }
+  out.push('');
+  out.push(`Most recent ${report.recent.length}:`);
+  for (const e of report.recent) {
+    const verdict = e.verdict ?? e.status ?? '-';
+    out.push(
+      `  ${e.ts}  ${e.task_id.padEnd(8)} ${e.role.padEnd(12)} ${verdict.padEnd(16)} $${e.cost_usd.toFixed(4)}`
+    );
+  }
+  return out.join('\n');
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms.toFixed(0)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rs = s - m * 60;
+  return `${m}m${rs.toFixed(0).padStart(2, '0')}s`;
+}

--- a/scripts/harness/lib/watch.test.ts
+++ b/scripts/harness/lib/watch.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { watchState } from './watch';
+import { appendEvent, initState } from './state-store';
+import { loadDispatchesLog } from './dispatches-log';
+
+let workDir: string;
+let statePath: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'watch-'));
+  statePath = join(workDir, '.harness/state.json');
+});
+
+describe('watchState — exits on orchestrate_end', () => {
+  it('prints all events appended before orchestrate_end and returns', async () => {
+    initState('T-99', statePath);
+    appendEvent(
+      statePath,
+      {
+        task_id: 'T-99',
+        type: 'orchestrate_start',
+        payload: { caps: {} },
+      },
+      { dispatchesLogPath: null }
+    );
+    appendEvent(
+      statePath,
+      {
+        task_id: 'T-99',
+        type: 'dispatch_start',
+        payload: { role: 'builder', attempt: 1 },
+      },
+      { dispatchesLogPath: null }
+    );
+    appendEvent(
+      statePath,
+      {
+        task_id: 'T-99',
+        type: 'dispatch_end',
+        payload: {
+          role: 'builder',
+          cost_usd: 0.5,
+          duration_ms: 60000,
+          num_turns: 5,
+          session_id: 's',
+          stop_reason: 'end_turn',
+          status: 'success',
+          commit_sha: 'abc12345',
+        },
+      },
+      { dispatchesLogPath: null }
+    );
+    appendEvent(
+      statePath,
+      {
+        task_id: 'T-99',
+        type: 'orchestrate_end',
+        payload: { outcome: 'success', totalCostUsd: 0.5 },
+      },
+      { dispatchesLogPath: null }
+    );
+
+    const lines: string[] = [];
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await watchState({
+      statePath,
+      intervalMs: 1,
+      noColor: true,
+      write: (s) => lines.push(s),
+      sleep,
+    });
+
+    const out = lines.join('');
+    expect(out).toMatch(/START/);
+    expect(out).toMatch(/dispatch_start.*builder/);
+    expect(out).toMatch(/dispatch_end.*builder.*status=success/);
+    expect(out).toMatch(/sha=abc12345/);
+    expect(out).toMatch(/END/);
+    // Cumulative cost meter should appear once we've seen the dispatch_end.
+    expect(out).toMatch(/\[\$0\.5000\]/);
+  });
+
+  it('waits for the file to appear when state.json does not yet exist', async () => {
+    let polls = 0;
+    const sleep = vi.fn().mockImplementation(async () => {
+      polls += 1;
+      if (polls === 2) {
+        // After two polls, create state with an orchestrate_end so the loop can finish.
+        initState('T-1', statePath);
+        appendEvent(
+          statePath,
+          {
+            task_id: 'T-1',
+            type: 'orchestrate_end',
+            payload: { outcome: 'success' },
+          },
+          { dispatchesLogPath: null }
+        );
+      }
+    });
+    const lines: string[] = [];
+    await watchState({
+      statePath,
+      intervalMs: 1,
+      noColor: true,
+      write: (s) => lines.push(s),
+      sleep,
+    });
+    expect(lines.join('')).toMatch(/waiting for/);
+    expect(lines.join('')).toMatch(/END/);
+  });
+
+  it('respects maxWaitMs when no orchestrate_end ever fires', async () => {
+    initState('T-1', statePath);
+    let calls = 0;
+    const now = vi.fn().mockImplementation(() => calls++ * 100);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const lines: string[] = [];
+    await watchState({
+      statePath,
+      intervalMs: 1,
+      maxWaitMs: 200,
+      noColor: true,
+      write: (s) => lines.push(s),
+      sleep,
+      now,
+    });
+    expect(lines.join('')).toMatch(/max wait/);
+  });
+});
+
+describe('appendEvent — JSONL dual-write (Axis 5 integration)', () => {
+  it('writes a dispatch_end event to BOTH state.json and dispatches.jsonl', () => {
+    const dispatchesPath = join(workDir, '.harness/dispatches.jsonl');
+    initState('T-99', statePath);
+    appendEvent(
+      statePath,
+      {
+        task_id: 'T-99',
+        type: 'dispatch_end',
+        payload: {
+          role: 'builder',
+          cost_usd: 0.5,
+          duration_ms: 1000,
+          num_turns: 5,
+          session_id: 'sess',
+          stop_reason: 'end_turn',
+          status: 'success',
+          commit_sha: 'abc',
+        },
+      },
+      { dispatchesLogPath: dispatchesPath }
+    );
+    // The default behavior (no override) would compute the path from the
+    // state.json's directory; here we pass the path explicitly and verify
+    // the JSONL got a line.
+
+    const entries = loadDispatchesLog(dispatchesPath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      task_id: 'T-99',
+      role: 'builder',
+      status: 'success',
+      cost_usd: 0.5,
+    });
+  });
+
+  it('does NOT write non-dispatch events to dispatches.jsonl', () => {
+    const dispatchesPath = join(workDir, '.harness/dispatches.jsonl');
+    initState('T-99', statePath);
+    appendEvent(
+      statePath,
+      {
+        task_id: 'T-99',
+        type: 'orchestrate_start',
+        payload: { caps: {} },
+      },
+      { dispatchesLogPath: dispatchesPath }
+    );
+
+    const entries = loadDispatchesLog(dispatchesPath);
+    expect(entries).toEqual([]);
+  });
+
+  it('skips JSONL write entirely when dispatchesLogPath is null', () => {
+    const dispatchesPath = join(workDir, '.harness/dispatches.jsonl');
+    initState('T-99', statePath);
+    appendEvent(
+      statePath,
+      {
+        task_id: 'T-99',
+        type: 'dispatch_end',
+        payload: {
+          role: 'builder',
+          cost_usd: 0.5,
+          duration_ms: 1,
+          num_turns: 1,
+          session_id: 's',
+          stop_reason: 'end_turn',
+          status: 'success',
+        },
+      },
+      { dispatchesLogPath: null }
+    );
+
+    expect(existsSync(dispatchesPath)).toBe(false);
+  });
+});

--- a/scripts/harness/lib/watch.ts
+++ b/scripts/harness/lib/watch.ts
@@ -1,0 +1,202 @@
+/**
+ * `harness watch` — pretty-print orchestrator events as they're appended
+ * to state.json (Axis 4 — round 43).
+ *
+ * Polls the file at a configurable interval, prints any events not yet
+ * shown. Exits cleanly on `orchestrate_end` (or Ctrl+C).
+ *
+ * fs.watch is unreliable on macOS for files written via atomic-rename
+ * (which writeStateAtomic in state-store.ts uses) — the watcher fires on
+ * the temp-file's create, then the rename triggers a separate inode and
+ * the watcher detaches. Polling is duller but works everywhere.
+ */
+
+import { existsSync } from 'node:fs';
+import {
+  loadState,
+  type StateEvent,
+  type OrchestratorState,
+} from './state-store';
+
+export interface WatchOptions {
+  /** Path to the state.json to watch. */
+  statePath: string;
+  /** Poll interval in milliseconds. Default 500ms. */
+  intervalMs?: number;
+  /** Hard cap — stop watching after this many ms even if no orchestrate_end. */
+  maxWaitMs?: number;
+  /** Sink for output. Defaults to process.stdout.write. */
+  write?: (s: string) => void;
+  /** Sleep impl (test seam). */
+  sleep?: (ms: number) => Promise<void>;
+  /** When true, omit ANSI color codes (for non-TTY or `--no-color`). */
+  noColor?: boolean;
+  /** Inject `Date.now()` (test seam). */
+  now?: () => number;
+}
+
+const ANSI = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+};
+
+export async function watchState(opts: WatchOptions): Promise<void> {
+  const intervalMs = opts.intervalMs ?? 500;
+  const maxWaitMs = opts.maxWaitMs ?? 60 * 60 * 1000;
+  const write = opts.write ?? ((s: string) => process.stdout.write(s));
+  const sleep = opts.sleep ?? defaultSleep;
+  const now = opts.now ?? (() => Date.now());
+
+  const startMs = now();
+  let seenCount = 0;
+  let cumulativeCostUsd = 0;
+  const fileExistsAtStart = existsSync(opts.statePath);
+  if (!fileExistsAtStart) {
+    write(
+      paint(
+        opts,
+        ANSI.dim,
+        `harness watch: waiting for ${opts.statePath} to appear...\n`
+      )
+    );
+  }
+
+  while (true) {
+    if (now() - startMs > maxWaitMs) {
+      write(
+        paint(
+          opts,
+          ANSI.dim,
+          `\nharness watch: max wait (${(maxWaitMs / 1000 / 60).toFixed(0)} min) reached; exiting.\n`
+        )
+      );
+      return;
+    }
+
+    const state = loadState(opts.statePath);
+    if (!state) {
+      await sleep(intervalMs);
+      continue;
+    }
+
+    const events = state.events;
+    if (events.length > seenCount) {
+      for (let i = seenCount; i < events.length; i++) {
+        const e = events[i]!;
+        const cost = numericPayloadField(e, 'cost_usd');
+        if (cost !== null) cumulativeCostUsd += cost;
+        write(formatEvent(e, state, cumulativeCostUsd, opts) + '\n');
+      }
+      seenCount = events.length;
+    }
+
+    // Stop on orchestrate_end (the loop wrote everything; nothing more coming).
+    if (events.some((e) => e.type === 'orchestrate_end')) {
+      return;
+    }
+
+    await sleep(intervalMs);
+  }
+}
+
+function paint(opts: WatchOptions, color: string, text: string): string {
+  if (opts.noColor) return text;
+  return `${color}${text}${ANSI.reset}`;
+}
+
+function numericPayloadField(e: StateEvent, key: string): number | null {
+  const v = e.payload[key];
+  return typeof v === 'number' ? v : null;
+}
+
+function formatEvent(
+  e: StateEvent,
+  state: OrchestratorState,
+  cumulativeCostUsd: number,
+  opts: WatchOptions
+): string {
+  const elapsedSec = Math.floor(
+    (new Date(e.ts).getTime() - new Date(state.started_at).getTime()) / 1000
+  );
+  const elapsedStr = `T+${formatElapsed(elapsedSec)}`.padStart(8);
+  const tag = formatEventTag(e, opts);
+  const detail = formatEventDetail(e);
+  const costMeter =
+    cumulativeCostUsd > 0
+      ? paint(opts, ANSI.dim, ` [$${cumulativeCostUsd.toFixed(4)}]`)
+      : '';
+  return `${paint(opts, ANSI.dim, elapsedStr)}  ${tag}  ${detail}${costMeter}`;
+}
+
+function formatEventTag(e: StateEvent, opts: WatchOptions): string {
+  switch (e.type) {
+    case 'orchestrate_start':
+      return paint(opts, ANSI.bold + ANSI.cyan, '▶ START          ');
+    case 'orchestrate_end': {
+      const outcome = String(e.payload.outcome ?? '');
+      const color =
+        outcome === 'success' ? ANSI.bold + ANSI.green : ANSI.bold + ANSI.red;
+      return paint(opts, color, '■ END            ');
+    }
+    case 'dispatch_start': {
+      const role = String(e.payload.role ?? '');
+      return paint(opts, ANSI.blue, `→ dispatch_start ${role.padEnd(12)}`);
+    }
+    case 'dispatch_end': {
+      const role = String(e.payload.role ?? '');
+      const verdict =
+        e.payload.verdict ?? e.payload.status ?? e.payload.parse_error ?? '';
+      const color =
+        verdict === 'approve' || verdict === 'success'
+          ? ANSI.green
+          : verdict === 'veto' || verdict === 'verify_fail'
+            ? ANSI.yellow
+            : ANSI.dim;
+      return paint(opts, color, `← dispatch_end   ${role.padEnd(12)}`);
+    }
+    case 'amendment_applied':
+      return paint(opts, ANSI.green, '✎ amendment_app  ');
+    case 'amendment_apply_failed':
+      return paint(opts, ANSI.red, '✗ amendment_fail ');
+    case 'cycle_halt':
+      return paint(opts, ANSI.bold + ANSI.red, '⊘ cycle_halt     ');
+    case 'pushback_dispatch':
+      return paint(opts, ANSI.cyan, '⟲ pushback       ');
+  }
+}
+
+function formatEventDetail(e: StateEvent): string {
+  const p = e.payload;
+  const parts: string[] = [];
+  if (typeof p.attempt === 'number') parts.push(`attempt=${p.attempt}`);
+  if (typeof p.diff_sha === 'string')
+    parts.push(`diff=${(p.diff_sha as string).slice(0, 8)}`);
+  if (typeof p.commit_sha === 'string')
+    parts.push(`sha=${(p.commit_sha as string).slice(0, 8)}`);
+  if (typeof p.status === 'string') parts.push(`status=${p.status}`);
+  if (typeof p.verdict === 'string') parts.push(`verdict=${p.verdict}`);
+  if (typeof p.findings_count === 'number')
+    parts.push(`findings=${p.findings_count}`);
+  if (typeof p.outcome === 'string') parts.push(`outcome=${p.outcome}`);
+  if (typeof p.reason === 'string') parts.push(p.reason as string);
+  if (typeof p.parse_error === 'string')
+    parts.push(`parse_error=${p.parse_error}`);
+  return parts.join(' ');
+}
+
+function formatElapsed(sec: number): string {
+  if (sec < 60) return `${sec}s`;
+  const m = Math.floor(sec / 60);
+  const s = sec - m * 60;
+  return `${m}m${String(s).padStart(2, '0')}s`;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}


### PR DESCRIPTION
## Summary
First round of harness improvements after PR-B trio. Closes plan §11 axes 4 + 5. Pure harness code; \$0 subagent.

**Axis 5 — long-term logging:**
- New \`.harness/dispatches.jsonl\`: append-only, one line per dispatch_end / pushback_dispatch event. Survives across runs and tasks.
- \`appendEvent\` dual-writes (state.json unchanged + JSONL additive). Backward-compatible — \`dispatchesLogPath: null\` opts out.
- New \`harness stats [--task X] [--role Y] [--since ISO] [--json]\` — aggregates over the JSONL: per-role cost histogram, verdict/status distribution, cold-reader veto rate, builder success rate, per-task rollup, recent N.

**Axis 4 — progress reporting:**
- New \`harness watch [--state PATH] [--no-color]\` — polls state.json (500ms default), pretty-prints each event with elapsed-time stamp, color-coded by event type, running cost meter. Exits on \`orchestrate_end\` or maxWait cap.
- File-poll over fs.watch because state.json uses atomic-rename writes, which break inode-watching on macOS.

**Tests:** 21 new (dispatches-log: 4, stats: 11, watch: 6 — including 3 dual-write integration assertions). 1166/1167 full suite pass.

**Plan §11 next:** Axis 6 (deterministic tools — task_what symbol validation + verify-command derivation).

Cites §11 (Axes 4+5).

## Test plan
- [x] preflight green
- [x] \`harness stats\` smoke (graceful empty-state when no dispatches yet)
- [x] CLI \`-h\` shows new commands and flags
- [ ] Hand-test \`harness watch\` against next \`harness orchestrate\` (dispatches.jsonl will populate organically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)