### PR TITLE
feat(harness): deterministic task-contract pre-flight (Axis 6, PR-D-1)

### DIFF
--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -33,6 +33,7 @@ import {
   buildColdReaderInput,
   formatColdReaderInputMarkdown,
 } from './lib/cold-reader-input.ts';
+import { checkTaskContract } from './lib/task-contract-check.ts';
 import {
   buildDriftArbiterInput,
   formatDriftArbiterInputMarkdown,
@@ -449,6 +450,7 @@ function main(): void {
         specMarkdown: specMd,
         designMarkdown: designMd,
         diff,
+        taskContractCheck: checkTaskContract(task.what, diff),
       });
 
       if (values.json) {

--- a/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
+++ b/scripts/harness/evals/cli-snapshots/snapshots/cold-read-T-01-no-diff.snapshot.md
@@ -71,20 +71,32 @@ seven numbers. If a concern doesn't fit one of these, do not emit it.
    section are mutually satisfiable.** Methodology basis: round-25
    builder pre-flight caught this on T-06 after five rounds of design
    cold-reads missed it.
-7. **Task contract conformance** (added round 42, finding #6). Read the
-   `task_what` input verbatim. For every method name, symbol, file path,
-   option, or behavior named there, check that the diff implements it
-   with the **exact name** given. Renaming (`setSeverity` accepting `null`
-   instead of separate `setSeverity` + `clearSeverity` when both are
-   named), collapsing (4 methods where 6 are named), reshaping (caller-
-   supplied arg where the task says service computes), or omitting any
-   named entity is a divergence. Emit as **CRITICAL** if the omission
-   breaks a contract callers will rely on; **HIGH** if it's silently
-   collapsing a named symmetry. Methodology basis: T-17 (round 37) shipped
-   with two such divergences and cold-reader missed both because it had
-   no access to the task body — the cited BRs were too loose to constrain
-   the API shape. The `task_what` field exists precisely so this scope
-   has bite.
+7. **Task contract conformance** (added round 42, finding #6; pre-flight
+   added round 44, Axis 6). Read the `task_what` input verbatim. For every
+   method name, symbol, file path, option, or behavior named there, check
+   that the diff implements it with the **exact name** given. Renaming
+   (`setSeverity` accepting `null` instead of separate `setSeverity` +
+   `clearSeverity` when both are named), collapsing (4 methods where 6
+   are named), reshaping (caller-supplied arg where the task says service
+   computes), or omitting any named entity is a divergence. Emit as
+   **CRITICAL** if the omission breaks a contract callers will rely on;
+   **HIGH** if it's silently collapsing a named symmetry.
+
+   **Pre-flight input (Axis 6):** when a `## Pre-flight: task contract
+   symbols` section appears in your input, treat its `Missing` list as
+   authoritative — the harness has already grepped the diff for each
+   backtick-quoted symbol from `task_what`. Each `Missing` entry is a
+   scope_check 7 candidate; you decide severity (CRITICAL vs HIGH) and
+   whether the cited spec/design explicitly permits the omission. You
+   do NOT need to re-derive symbols the pre-flight already classified
+   `Present`; trust the evidence line. If pre-flight is absent (older
+   inputs or empty `task_what`), do the derivation yourself.
+
+   Methodology basis: T-17 (round 37) shipped with two such divergences
+   and cold-reader missed both because it had no access to the task
+   body — the cited BRs were too loose to constrain the API shape. The
+   `task_what` field exists precisely so this scope has bite; the
+   pre-flight removes verdict non-determinism on the mechanical step.
 
 ---
 
@@ -201,6 +213,27 @@ method/symbol/file/option named here as a verbatim requirement; renaming,
 collapsing, or omitting any named entity is a divergence (see scope_check 7)._
 
 Create `src/features/incidents/types.ts` with `Incident`, `IncidentTypeId`, `Severity`, `ChipId`, `JournalEntry`, `IncidentCreateInput`, `IncidentUpdateInput`. Include the BR-29 runtime-invariant comment from design §D3.
+
+## Pre-flight: task contract symbols
+
+_Mechanical pre-flight (Axis 6): each backtick-quoted symbol from the
+'What' line above was searched in the diff. Treat this list as
+authoritative for scope_check 7 — you do not need to re-derive it.
+A symbol marked MISSING is a divergence unless the cited spec/design
+explicitly permits the omission._
+
+**Present (0):**
+- _(none)_
+
+**Missing (8):**
+- `src/features/incidents/types.ts` (path)
+- `Incident` (identifier)
+- `IncidentTypeId` (identifier)
+- `Severity` (identifier)
+- `ChipId` (identifier)
+- `JournalEntry` (identifier)
+- `IncidentCreateInput` (identifier)
+- `IncidentUpdateInput` (identifier)
 
 ## Cited spec sections
 

--- a/scripts/harness/lib/cold-reader-input.test.ts
+++ b/scripts/harness/lib/cold-reader-input.test.ts
@@ -247,3 +247,116 @@ describe('formatColdReaderInputMarkdown', () => {
     expect(out2).toMatch(/_\(none — empty diff\)_/);
   });
 });
+
+describe('formatColdReaderInputMarkdown — task-contract-check pre-flight (Axis 6)', () => {
+  const baseInput = buildColdReaderInput({
+    task: task('T-01'),
+    specMarkdown: specMd,
+    designMarkdown: designMd,
+    diff: SAMPLE_DIFF,
+  });
+
+  it('omits the pre-flight section when no check is provided', () => {
+    const out = formatColdReaderInputMarkdown(baseInput);
+    expect(out).not.toMatch(/Pre-flight: task contract symbols/);
+  });
+
+  it('omits the pre-flight section when the check has zero symbols', () => {
+    const out = formatColdReaderInputMarkdown({
+      ...baseInput,
+      task_contract_check: { symbols: [], present: [], missing: [] },
+    });
+    expect(out).not.toMatch(/Pre-flight: task contract symbols/);
+  });
+
+  it('renders present + missing partitions when symbols exist', () => {
+    const present = {
+      symbol: 'Incident',
+      kind: 'identifier' as const,
+      present: true,
+      evidence: '+export interface Incident {',
+    };
+    const missing = {
+      symbol: 'JournalEntry',
+      kind: 'identifier' as const,
+      present: false,
+      evidence: null,
+    };
+    const out = formatColdReaderInputMarkdown({
+      ...baseInput,
+      task_contract_check: {
+        symbols: [present, missing],
+        present: [present],
+        missing: [missing],
+      },
+    });
+    expect(out).toMatch(/## Pre-flight: task contract symbols/);
+    expect(out).toMatch(/scope_check 7/);
+    expect(out).toMatch(/\*\*Present \(1\):\*\*/);
+    expect(out).toMatch(
+      /`Incident` \(identifier\) — \+export interface Incident/
+    );
+    expect(out).toMatch(/\*\*Missing \(1\):\*\*/);
+    expect(out).toMatch(/`JournalEntry` \(identifier\)/);
+  });
+
+  it('shows _(none)_ markers for empty partitions', () => {
+    const sym = {
+      symbol: 'Incident',
+      kind: 'identifier' as const,
+      present: true,
+      evidence: '+interface Incident {}',
+    };
+    const out = formatColdReaderInputMarkdown({
+      ...baseInput,
+      task_contract_check: {
+        symbols: [sym],
+        present: [sym],
+        missing: [],
+      },
+    });
+    expect(out).toMatch(/all task-contract symbols present/);
+  });
+});
+
+describe('buildColdReaderInput — accepts taskContractCheck option', () => {
+  it('passes the check through to the output', () => {
+    const fakeCheck = {
+      symbols: [
+        {
+          symbol: 'Incident',
+          kind: 'identifier' as const,
+          present: true,
+          evidence: 'line',
+        },
+      ],
+      present: [
+        {
+          symbol: 'Incident',
+          kind: 'identifier' as const,
+          present: true,
+          evidence: 'line',
+        },
+      ],
+      missing: [],
+    };
+    const input = buildColdReaderInput({
+      task: task('T-01'),
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+      diff: SAMPLE_DIFF,
+      taskContractCheck: fakeCheck,
+    });
+    expect(input.task_contract_check).toBe(fakeCheck);
+  });
+
+  it('defaults task_contract_check to null when not provided', () => {
+    const input = buildColdReaderInput({
+      task: task('T-01'),
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+      diff: SAMPLE_DIFF,
+    });
+    expect(input.task_contract_check).toBeNull();
+  });
+});

--- a/scripts/harness/lib/cold-reader-input.ts
+++ b/scripts/harness/lib/cold-reader-input.ts
@@ -9,6 +9,7 @@
  */
 
 import { extractRequirement, extractSpecSection } from './spec-parser';
+import type { TaskContractCheckResult } from './task-contract-check';
 import type { Citation, Task } from './task-parser';
 
 export interface ColdReaderInput {
@@ -32,6 +33,12 @@ export interface ColdReaderInput {
   changed_files: string[];
   /** Refs the task cited that we couldn't extract — same surfacing pattern as BuilderInput. */
   missing_citations: string[];
+  /** Pre-flight result from task-contract-check.ts (Axis 6). When provided,
+   * the markdown formatter renders a "## Pre-flight: task contract symbols"
+   * section so the cold-reader gets authoritative present/missing-symbol data
+   * rather than re-deriving it from the diff. Null/omitted = pre-flight not
+   * run (older callers, or when task_what is empty). */
+  task_contract_check?: TaskContractCheckResult | null;
 }
 
 export interface BuildColdReaderInputOptions {
@@ -40,6 +47,8 @@ export interface BuildColdReaderInputOptions {
   designMarkdown: string;
   /** Raw `git diff` output. */
   diff: string;
+  /** Optional pre-flight task-contract result (Axis 6). */
+  taskContractCheck?: TaskContractCheckResult | null;
 }
 
 /**
@@ -48,7 +57,7 @@ export interface BuildColdReaderInputOptions {
 export function buildColdReaderInput(
   opts: BuildColdReaderInputOptions
 ): ColdReaderInput {
-  const { task, specMarkdown, designMarkdown, diff } = opts;
+  const { task, specMarkdown, designMarkdown, diff, taskContractCheck } = opts;
 
   const specCites: Array<{ ref: string; body: string }> = [];
   const designCites: Array<{ ref: string; body: string }> = [];
@@ -75,6 +84,7 @@ export function buildColdReaderInput(
     diff,
     changed_files: extractChangedFiles(diff),
     missing_citations: missing,
+    task_contract_check: taskContractCheck ?? null,
   };
 }
 
@@ -142,6 +152,45 @@ export function formatColdReaderInputMarkdown(input: ColdReaderInput): string {
     );
     out.push('');
     out.push(input.task_what.trim());
+    out.push('');
+  }
+
+  if (
+    input.task_contract_check &&
+    input.task_contract_check.symbols.length > 0
+  ) {
+    const tcc = input.task_contract_check;
+    out.push('## Pre-flight: task contract symbols');
+    out.push('');
+    out.push(
+      '_Mechanical pre-flight (Axis 6): each backtick-quoted symbol from the'
+    );
+    out.push("'What' line above was searched in the diff. Treat this list as");
+    out.push(
+      'authoritative for scope_check 7 — you do not need to re-derive it.'
+    );
+    out.push(
+      'A symbol marked MISSING is a divergence unless the cited spec/design'
+    );
+    out.push('explicitly permits the omission._');
+    out.push('');
+    out.push(`**Present (${tcc.present.length}):**`);
+    if (tcc.present.length === 0) {
+      out.push('- _(none)_');
+    } else {
+      for (const s of tcc.present) {
+        out.push(`- \`${s.symbol}\` (${s.kind}) — ${s.evidence ?? ''}`);
+      }
+    }
+    out.push('');
+    out.push(`**Missing (${tcc.missing.length}):**`);
+    if (tcc.missing.length === 0) {
+      out.push('- _(none — all task-contract symbols present)_');
+    } else {
+      for (const s of tcc.missing) {
+        out.push(`- \`${s.symbol}\` (${s.kind})`);
+      }
+    }
     out.push('');
   }
 

--- a/scripts/harness/lib/dispatch/cold-reader-dispatch.ts
+++ b/scripts/harness/lib/dispatch/cold-reader-dispatch.ts
@@ -12,6 +12,7 @@ import {
   buildColdReaderInput,
   formatColdReaderInputMarkdown,
 } from '../cold-reader-input';
+import { checkTaskContract } from '../task-contract-check';
 import { parseTaskList } from '../task-parser';
 import { dispatchSubagent, type DispatchResult } from '../subagent-dispatch';
 import { parseStructuredExit } from './parse-structured-exit';
@@ -77,11 +78,15 @@ export async function dispatchColdReader(
   if (!task) {
     throw new Error(`cold-reader dispatch: task ${opts.taskId} not found`);
   }
+  // Axis 6 finding #6: pre-flag task-contract symbols mechanically rather
+  // than relying on the cold-reader to re-derive them from the 'What' line.
+  const taskContractCheck = checkTaskContract(task.what, diff);
   const crInput = buildColdReaderInput({
     task,
     specMarkdown: specMd,
     designMarkdown: designMd,
     diff,
+    taskContractCheck,
   });
   const inputMd = formatColdReaderInputMarkdown(crInput);
 

--- a/scripts/harness/lib/prompts/cold-reader-code.md
+++ b/scripts/harness/lib/prompts/cold-reader-code.md
@@ -71,20 +71,32 @@ seven numbers. If a concern doesn't fit one of these, do not emit it.
    section are mutually satisfiable.** Methodology basis: round-25
    builder pre-flight caught this on T-06 after five rounds of design
    cold-reads missed it.
-7. **Task contract conformance** (added round 42, finding #6). Read the
-   `task_what` input verbatim. For every method name, symbol, file path,
-   option, or behavior named there, check that the diff implements it
-   with the **exact name** given. Renaming (`setSeverity` accepting `null`
-   instead of separate `setSeverity` + `clearSeverity` when both are
-   named), collapsing (4 methods where 6 are named), reshaping (caller-
-   supplied arg where the task says service computes), or omitting any
-   named entity is a divergence. Emit as **CRITICAL** if the omission
-   breaks a contract callers will rely on; **HIGH** if it's silently
-   collapsing a named symmetry. Methodology basis: T-17 (round 37) shipped
-   with two such divergences and cold-reader missed both because it had
-   no access to the task body — the cited BRs were too loose to constrain
-   the API shape. The `task_what` field exists precisely so this scope
-   has bite.
+7. **Task contract conformance** (added round 42, finding #6; pre-flight
+   added round 44, Axis 6). Read the `task_what` input verbatim. For every
+   method name, symbol, file path, option, or behavior named there, check
+   that the diff implements it with the **exact name** given. Renaming
+   (`setSeverity` accepting `null` instead of separate `setSeverity` +
+   `clearSeverity` when both are named), collapsing (4 methods where 6
+   are named), reshaping (caller-supplied arg where the task says service
+   computes), or omitting any named entity is a divergence. Emit as
+   **CRITICAL** if the omission breaks a contract callers will rely on;
+   **HIGH** if it's silently collapsing a named symmetry.
+
+   **Pre-flight input (Axis 6):** when a `## Pre-flight: task contract
+symbols` section appears in your input, treat its `Missing` list as
+   authoritative — the harness has already grepped the diff for each
+   backtick-quoted symbol from `task_what`. Each `Missing` entry is a
+   scope_check 7 candidate; you decide severity (CRITICAL vs HIGH) and
+   whether the cited spec/design explicitly permits the omission. You
+   do NOT need to re-derive symbols the pre-flight already classified
+   `Present`; trust the evidence line. If pre-flight is absent (older
+   inputs or empty `task_what`), do the derivation yourself.
+
+   Methodology basis: T-17 (round 37) shipped with two such divergences
+   and cold-reader missed both because it had no access to the task
+   body — the cited BRs were too loose to constrain the API shape. The
+   `task_what` field exists precisely so this scope has bite; the
+   pre-flight removes verdict non-determinism on the mechanical step.
 
 ---
 

--- a/scripts/harness/lib/task-contract-check.test.ts
+++ b/scripts/harness/lib/task-contract-check.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for task-contract-check.ts — deterministic pre-flight that extracts
+ * named symbols from a task's `What:` line and checks each against the diff.
+ *
+ * Drives Axis 6 / finding #6: cold-reader scope #7 (task-contract conformance)
+ * was previously the model's job; this lifts it to a mechanical check whose
+ * results get injected into the cold-reader input.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkTaskContract,
+  extractTaskWhatSymbols,
+} from './task-contract-check';
+
+describe('extractTaskWhatSymbols', () => {
+  it('returns an empty list for null/empty input', () => {
+    expect(extractTaskWhatSymbols(null)).toEqual([]);
+    expect(extractTaskWhatSymbols('')).toEqual([]);
+    expect(extractTaskWhatSymbols('   ')).toEqual([]);
+  });
+
+  it('extracts backtick-quoted identifiers and classifies them', () => {
+    const what =
+      'Create `src/features/incidents/types.ts` with `Incident`, `Severity`, `JournalEntry`.';
+    const symbols = extractTaskWhatSymbols(what);
+    const map = new Map(symbols.map((s) => [s.symbol, s.kind]));
+    expect(map.get('src/features/incidents/types.ts')).toBe('path');
+    expect(map.get('Incident')).toBe('identifier');
+    expect(map.get('Severity')).toBe('identifier');
+    expect(map.get('JournalEntry')).toBe('identifier');
+  });
+
+  it('strips parens from method-call-style backticks', () => {
+    const what = 'Methods: `create(input)`, `get(id)`, `findActiveForUser()`.';
+    const symbols = extractTaskWhatSymbols(what);
+    const names = symbols.map((s) => s.symbol);
+    expect(names).toContain('create');
+    expect(names).toContain('get');
+    expect(names).toContain('findActiveForUser');
+    expect(names).not.toContain('create(input)');
+  });
+
+  it('dedupes repeated symbols', () => {
+    const what = 'Add `appendJournal` and `appendJournal` again.';
+    const symbols = extractTaskWhatSymbols(what);
+    expect(symbols.filter((s) => s.symbol === 'appendJournal')).toHaveLength(1);
+  });
+
+  it('classifies path-like tokens by slash-or-dot+letter pattern', () => {
+    const what =
+      'Touch `firestore.rules` and `src/App.tsx` and `package.json`.';
+    const map = new Map(
+      extractTaskWhatSymbols(what).map((s) => [s.symbol, s.kind])
+    );
+    expect(map.get('firestore.rules')).toBe('path');
+    expect(map.get('src/App.tsx')).toBe('path');
+    expect(map.get('package.json')).toBe('path');
+  });
+
+  it('skips tokens that look like prose (multi-word, contains spaces)', () => {
+    const what = 'Add `RMW per design §D3` somewhere.';
+    const symbols = extractTaskWhatSymbols(what);
+    expect(symbols.find((s) => s.symbol.includes(' '))).toBeUndefined();
+  });
+
+  it('skips citation-style tokens like `BR-7`', () => {
+    const what = 'Implements `BR-7` and `AC-3` and `§D5`.';
+    const symbols = extractTaskWhatSymbols(what);
+    expect(symbols.map((s) => s.symbol)).not.toContain('BR-7');
+    expect(symbols.map((s) => s.symbol)).not.toContain('AC-3');
+    expect(symbols.map((s) => s.symbol)).not.toContain('§D5');
+  });
+});
+
+describe('checkTaskContract', () => {
+  const sampleDiff = `diff --git a/src/features/incidents/types.ts b/src/features/incidents/types.ts
+new file mode 100644
+--- /dev/null
++++ b/src/features/incidents/types.ts
+@@
++export interface Incident { id: string }
++export type Severity = 'mild' | 'severe';
++export interface JournalEntry { ts: number }
+`;
+
+  it('returns all-present when every symbol appears in the diff', () => {
+    const what =
+      'Create `src/features/incidents/types.ts` with `Incident`, `Severity`, `JournalEntry`.';
+    const result = checkTaskContract(what, sampleDiff);
+    expect(result.symbols).toHaveLength(4);
+    expect(result.missing).toEqual([]);
+    expect(result.present.map((s) => s.symbol).sort()).toEqual(
+      [
+        'Incident',
+        'JournalEntry',
+        'Severity',
+        'src/features/incidents/types.ts',
+      ].sort()
+    );
+  });
+
+  it('flags missing symbols absent from the diff', () => {
+    const what = 'Add `Incident`, `Severity`, `JournalEntry`, `MissingThing`.';
+    const result = checkTaskContract(what, sampleDiff);
+    const missingNames = result.missing.map((s) => s.symbol);
+    expect(missingNames).toContain('MissingThing');
+    expect(missingNames).not.toContain('Incident');
+  });
+
+  it('matches identifier symbols on word boundaries (no substring matches)', () => {
+    const diff = `+++ b/foo.ts\n+const Severityish = 1;\n`;
+    const what = 'Add `Severity`.';
+    const result = checkTaskContract(what, diff);
+    expect(result.missing.map((s) => s.symbol)).toContain('Severity');
+  });
+
+  it('returns empty result for empty what', () => {
+    const result = checkTaskContract(null, sampleDiff);
+    expect(result.symbols).toEqual([]);
+    expect(result.present).toEqual([]);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('records evidence (first matching line) for present symbols', () => {
+    const what = 'Add `Incident`.';
+    const result = checkTaskContract(what, sampleDiff);
+    const incident = result.present.find((s) => s.symbol === 'Incident');
+    expect(incident?.evidence).toMatch(/interface Incident/);
+  });
+});

--- a/scripts/harness/lib/task-contract-check.ts
+++ b/scripts/harness/lib/task-contract-check.ts
@@ -1,0 +1,124 @@
+/**
+ * Deterministic pre-flight check that lifts cold-reader scope #7
+ * (task-contract conformance) from LLM judgment to mechanical derivation.
+ *
+ * Mechanism:
+ *   1. Extract backtick-quoted tokens from the task `What:` line.
+ *   2. Classify each as 'path' or 'identifier'; strip method-call parens.
+ *   3. Search the unified diff for each symbol (word-boundary for identifiers,
+ *      literal substring for paths).
+ *   4. Return present + missing partitions, with first-line evidence for
+ *      present symbols.
+ *
+ * The orchestrator runs this between builder success and cold-reader dispatch
+ * and injects the result into the cold-reader input. The cold-reader still
+ * makes the judgment call on whether a missing symbol matters — but it
+ * receives authoritative pre-flagged data rather than re-deriving it.
+ *
+ * Pure: no I/O, no project imports.
+ */
+
+export type SymbolKind = 'path' | 'identifier';
+
+export interface ExtractedSymbol {
+  symbol: string;
+  kind: SymbolKind;
+}
+
+export interface CheckedSymbol extends ExtractedSymbol {
+  present: boolean;
+  /** First diff line (trimmed) where the symbol matches; null if absent. */
+  evidence: string | null;
+}
+
+export interface TaskContractCheckResult {
+  symbols: CheckedSymbol[];
+  present: CheckedSymbol[];
+  missing: CheckedSymbol[];
+}
+
+/** Backtick-quoted tokens. Non-greedy, no nested backticks. */
+const BACKTICK_TOKEN = /`([^`\n]+)`/g;
+
+/** Citation refs we always skip — these are never code symbols. */
+const CITATION_RE = /^(?:BR|NFR|AC|US|OQ|DQ)-\d+$|^§D?\d+/i;
+
+/** A token is a "path" if it contains a slash OR a dot followed by letters. */
+function classify(symbol: string): SymbolKind {
+  if (symbol.includes('/')) return 'path';
+  if (/\.[A-Za-z]/.test(symbol)) return 'path';
+  return 'identifier';
+}
+
+/** Strip trailing `(...)` from a method-call-style backtick token. */
+function stripCallParens(token: string): string {
+  return token.replace(/\([^)]*\)\s*$/, '');
+}
+
+/**
+ * Pull named symbols out of a `What:` line. Skips citations, multi-word
+ * tokens (prose), and anything that doesn't look like a code identifier or
+ * path. Dedupes by symbol name.
+ */
+export function extractTaskWhatSymbols(what: string | null): ExtractedSymbol[] {
+  if (!what) return [];
+  const seen = new Set<string>();
+  const out: ExtractedSymbol[] = [];
+  for (const match of what.matchAll(BACKTICK_TOKEN)) {
+    const raw = match[1]!.trim();
+    if (!raw) continue;
+    const stripped = stripCallParens(raw).trim();
+    if (!stripped) continue;
+    if (stripped.includes(' ')) continue; // prose
+    if (CITATION_RE.test(stripped)) continue;
+    if (seen.has(stripped)) continue;
+    seen.add(stripped);
+    out.push({ symbol: stripped, kind: classify(stripped) });
+  }
+  return out;
+}
+
+/**
+ * Escape a string for safe use inside a RegExp. (No `RegExp.escape` in TS yet.)
+ */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Find the first diff line containing the symbol. For identifiers we use
+ * word-boundary matching to avoid `Severityish` matching `Severity`. For
+ * paths we use literal substring (paths often contain `/` and `.` which
+ * complicate word boundaries).
+ */
+function findEvidence(
+  symbol: string,
+  kind: SymbolKind,
+  diff: string
+): string | null {
+  const escaped = escapeRe(symbol);
+  const re =
+    kind === 'identifier'
+      ? new RegExp(`\\b${escaped}\\b`)
+      : new RegExp(escaped);
+  for (const line of diff.split('\n')) {
+    if (re.test(line)) return line.trim();
+  }
+  return null;
+}
+
+export function checkTaskContract(
+  what: string | null,
+  diff: string
+): TaskContractCheckResult {
+  const symbols = extractTaskWhatSymbols(what);
+  const checked: CheckedSymbol[] = symbols.map((s) => {
+    const evidence = findEvidence(s.symbol, s.kind, diff);
+    return { ...s, present: evidence !== null, evidence };
+  });
+  return {
+    symbols: checked,
+    present: checked.filter((s) => s.present),
+    missing: checked.filter((s) => !s.present),
+  };
+}


### PR DESCRIPTION
## Summary
- New `task-contract-check.ts`: extracts backtick-quoted symbols from a task's `What:` line, classifies as path/identifier, greps the diff. Returns present/missing partitions with first-line evidence.
- Cold-reader dispatcher and CLI both invoke the check and inject results into the cold-reader input under a new `## Pre-flight: task contract symbols` section.
- Cold-reader prompt's scope_check 7 updated to treat the pre-flight `Missing` list as authoritative; falls back to LLM derivation when pre-flight is absent.

## Why
Axis 6 / finding #6: T-17 (round 37) shipped two divergences that were mechanically detectable from the `What:` line — 4 methods named where 6 were required, and a reversed `appendJournal` computation site. Cold-reader missed both because it had to re-derive the contract from prose. This lifts that step to a deterministic check.

Also addresses verdict non-determinism (finding #12) on the mechanical portion: same diff now produces the same `Missing` list every time.

## What's NOT in this PR
- Tool #1 (`derive-verify-command.ts`) — ships in PR-D-2, separate.
- Tools #2/#3/#4 from plan §11 — deferred until 2nd recurrence per plan.

## Test plan
- [x] 12 new unit tests in `task-contract-check.test.ts` (extraction + check)
- [x] 6 new tests in `cold-reader-input.test.ts` for the rendered pre-flight section
- [x] CLI snapshot regenerated; `cli-snapshots/run.test.ts` passes
- [x] Full harness suite: 326/326 green
- [x] `pnpm run preflight`: lint + knip + build + test:coverage all green
- [ ] First live run on T-28 (slice-3 entry) will validate end-to-end behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)