### PR TITLE
feat(harness): deterministic verify-command derivation (Axis 6, PR-D-2)

### DIFF
--- a/scripts/harness/cli.ts
+++ b/scripts/harness/cli.ts
@@ -34,6 +34,7 @@ import {
   formatColdReaderInputMarkdown,
 } from './lib/cold-reader-input.ts';
 import { checkTaskContract } from './lib/task-contract-check.ts';
+import { deriveVerifyCommand } from './lib/derive-verify-command.ts';
 import {
   buildDriftArbiterInput,
   formatDriftArbiterInputMarkdown,
@@ -373,6 +374,7 @@ function main(): void {
         task,
         specMarkdown: specMd,
         designMarkdown: designMd,
+        derivedVerifyCommand: cliDeriveVerifyCommand(task.verify),
       });
 
       if (values.json) {
@@ -992,6 +994,19 @@ async function runWatch(
   );
   await watchState({ statePath: path, noColor });
   process.exit(0);
+}
+
+function cliDeriveVerifyCommand(
+  verifyLine: string | null
+): ReturnType<typeof deriveVerifyCommand> | null {
+  try {
+    const pkgPath = resolve(process.cwd(), 'package.json');
+    const raw = readFileSync(pkgPath, 'utf8');
+    const pkg = JSON.parse(raw) as { scripts?: Record<string, string> };
+    return deriveVerifyCommand(verifyLine, pkg);
+  } catch {
+    return null;
+  }
 }
 
 main();

--- a/scripts/harness/evals/cli-snapshots/snapshots/prepare-T-02.snapshot.md
+++ b/scripts/harness/evals/cli-snapshots/snapshots/prepare-T-02.snapshot.md
@@ -62,27 +62,23 @@ For every task:
    gold-plating.
 5. **Refactor.** Keep tests green.
 6. **Run the `Verify:` line literally.** It is the per-task gate.
-   - **If the verify line specifies a command verbatim** (e.g.
-     "`pnpm run test:rules` passes new assertions...") — run that
-     command exactly. Do NOT modify, augment, or substitute it.
-   - **If the verify line is descriptive** (e.g. "Component test:
-     tap fires the store action; aria-label matches the i18n value")
-     — derive the command from the project's actual test runner,
-     NOT from your own knowledge of similarly-named tools. Specifically:
-     - Read `package.json`'s `scripts` block first. Pick the closest
-       script (e.g. `test:unit`, `test`, `test:rules`).
-     - For unit tests against a single file in this project (Vitest):
-       `pnpm exec vitest run <path/to/file>`. Vitest takes positional
-       file paths, NOT Jest's `--testPathPattern` flag. Confirm by
-       checking which test framework the project's `package.json`
-       depends on (look for `vitest` vs `jest`).
-     - When in doubt, run the broadest local test command
-       (`pnpm run test:unit`) once to confirm the framework +
-       invocation pattern before constructing a narrower invocation.
-     - **Methodology basis:** round 27 hit `verify_fail` x4 because
-       the subagent invented `--testPathPattern` (Jest syntax) on a
-       Vitest project. Cost: $0.71 for a non-shipping result. This
-       rule generalizes the lesson.
+   - **If a `## Verify command (canonical, derived)` section appears in
+     your input (Axis 6 pre-derivation):** run that command exactly.
+     The harness has already mapped the verify line to a canonical pnpm
+     script in this project. Do NOT modify, augment, or substitute it.
+     If the canonical command fails for a structural reason (script
+     missing, wrong runner, infrastructure unavailable), emit `spec_gap`
+     rather than substituting your own command.
+   - **If no canonical section is present** (older harness or
+     `derived_verify_command.command` is null), fall back to deriving
+     yourself: read `package.json`'s `scripts` block, pick the closest
+     script (`test:unit`, `test:rules`, `lint`, `preflight`), and prefer
+     `pnpm exec vitest run <path>` for single-file Vitest invocations
+     (Vitest takes positional paths, NOT Jest's `--testPathPattern`).
+     **Methodology basis:** round 27 hit `verify_fail` x4 because the
+     subagent invented `--testPathPattern` (Jest syntax) on a Vitest
+     project — round 44 (Axis 6) lifted that derivation out of the
+     model into a deterministic step.
 7. **Run the verify ONE FINAL TIME** before constructing your exit
    payload. The TDD cycle in steps 3-5 includes test runs that are
    _expected_ to fail (RED → GREEN). Those iterations do NOT determine
@@ -364,6 +360,20 @@ Built with MUI `<Fab>`, positioned bottom-right with `position: fixed`. Tap targ
 ## Verify (the per-task gate)
 
 `useFeatureFlag('incidentsEnabled')` returns false by default; flipping the dev flag flips the value. Pattern matches existing `vetsEnabled`.
+
+## Verify command (canonical, derived)
+
+_Mechanical pre-derivation (Axis 6): the harness has already mapped
+the verify line above to a canonical pnpm script. Run this command —
+do NOT invent flags, framework syntax, or alternative scripts. If it
+fails for a structural reason (script missing, wrong runner) emit
+`spec_gap` rather than substituting your own command._
+
+```bash
+pnpm run test:unit
+```
+
+_Source: descriptive-default — descriptive verify line; defaulted to project's 'test:unit' script_
 
 ## Project context files
 

--- a/scripts/harness/lib/builder-input.test.ts
+++ b/scripts/harness/lib/builder-input.test.ts
@@ -197,3 +197,73 @@ describe('formatBuilderInputMarkdown', () => {
     expect(fakeMd).toMatch(/BR-999/);
   });
 });
+
+describe('buildBuilderInput — derived verify command (Axis 6)', () => {
+  it('passes a derived verify command through to the output', () => {
+    const dvc = {
+      command: 'pnpm run test:rules',
+      source: 'verbatim' as const,
+      reason: 'extracted from backticks',
+    };
+    const input = buildBuilderInput({
+      task: task('T-01'),
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+      derivedVerifyCommand: dvc,
+    });
+    expect(input.derived_verify_command).toBe(dvc);
+  });
+
+  it('defaults derived_verify_command to null when not provided', () => {
+    const input = buildBuilderInput({
+      task: task('T-01'),
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+    });
+    expect(input.derived_verify_command).toBeNull();
+  });
+
+  it('renders a "## Verify command (canonical, derived)" section in markdown', () => {
+    const input = buildBuilderInput({
+      task: task('T-01'),
+      specMarkdown: specMd,
+      designMarkdown: designMd,
+      derivedVerifyCommand: {
+        command: 'pnpm run preflight',
+        source: 'script-match',
+        reason: 'matched build keyword',
+      },
+    });
+    const md = formatBuilderInputMarkdown(input);
+    expect(md).toMatch(/## Verify command \(canonical, derived\)/);
+    expect(md).toMatch(/```bash\npnpm run preflight\n```/);
+    expect(md).toMatch(/Source: script-match — matched build keyword/);
+  });
+
+  it('omits the canonical section when derived_verify_command is null', () => {
+    const md = formatBuilderInputMarkdown(
+      buildBuilderInput({
+        task: task('T-01'),
+        specMarkdown: specMd,
+        designMarkdown: designMd,
+      })
+    );
+    expect(md).not.toMatch(/canonical, derived/);
+  });
+
+  it('omits the canonical section when command is null (unknown source)', () => {
+    const md = formatBuilderInputMarkdown(
+      buildBuilderInput({
+        task: task('T-01'),
+        specMarkdown: specMd,
+        designMarkdown: designMd,
+        derivedVerifyCommand: {
+          command: null,
+          source: 'unknown',
+          reason: 'no test scripts',
+        },
+      })
+    );
+    expect(md).not.toMatch(/canonical, derived/);
+  });
+});

--- a/scripts/harness/lib/builder-input.ts
+++ b/scripts/harness/lib/builder-input.ts
@@ -5,6 +5,7 @@
  * BuilderInput. The CLI wrapper handles file I/O.
  */
 
+import type { DerivedVerifyCommand } from './derive-verify-command';
 import {
   extractRequirement,
   extractSpecSection,
@@ -61,6 +62,11 @@ export interface BuilderInput {
    * dispatch — the agent can't satisfy citations that don't exist.
    */
   missing_citations: string[];
+  /** Optional canonical verify command derived from the verify line + the
+   * project's package.json (Axis 6). When provided, the markdown formatter
+   * renders a "## Verify command (canonical, derived)" section so the
+   * builder runs the canonical command rather than re-deriving it. */
+  derived_verify_command?: DerivedVerifyCommand | null;
 }
 
 export interface BuildBuilderInputOptions {
@@ -70,6 +76,8 @@ export interface BuildBuilderInputOptions {
   contextFiles?: string[];
   allowedWrites?: string[];
   budget?: BuilderInputBudget;
+  /** Optional pre-derived verify command (Axis 6). */
+  derivedVerifyCommand?: DerivedVerifyCommand | null;
 }
 
 /**
@@ -93,6 +101,7 @@ export function buildBuilderInput(
     contextFiles = ['CLAUDE.md'],
     allowedWrites = [],
     budget = DEFAULT_BUDGET,
+    derivedVerifyCommand,
   } = opts;
 
   const citations: ExtractedCitation[] = [];
@@ -122,6 +131,7 @@ export function buildBuilderInput(
     allowed_writes: allowedWrites,
     budget,
     missing_citations: missing,
+    derived_verify_command: derivedVerifyCommand ?? null,
   };
 }
 
@@ -181,6 +191,32 @@ export function formatBuilderInputMarkdown(input: BuilderInput): string {
     out.push('## Verify (the per-task gate)');
     out.push('');
     out.push(input.verify);
+    out.push('');
+  }
+
+  if (input.derived_verify_command && input.derived_verify_command.command) {
+    const dvc = input.derived_verify_command;
+    out.push('## Verify command (canonical, derived)');
+    out.push('');
+    out.push(
+      '_Mechanical pre-derivation (Axis 6): the harness has already mapped'
+    );
+    out.push(
+      'the verify line above to a canonical pnpm script. Run this command —'
+    );
+    out.push(
+      'do NOT invent flags, framework syntax, or alternative scripts. If it'
+    );
+    out.push(
+      'fails for a structural reason (script missing, wrong runner) emit'
+    );
+    out.push('`spec_gap` rather than substituting your own command._');
+    out.push('');
+    out.push('```bash');
+    out.push(dvc.command!);
+    out.push('```');
+    out.push('');
+    out.push(`_Source: ${dvc.source} — ${dvc.reason}_`);
     out.push('');
   }
 

--- a/scripts/harness/lib/derive-verify-command.test.ts
+++ b/scripts/harness/lib/derive-verify-command.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for derive-verify-command.ts — deterministic mapping from a task's
+ * `Verify:` line to a canonical pnpm command, replacing the LLM derivation
+ * the builder prompt previously instructed (round 27 cost: $0.71 invented
+ * Jest --testPathPattern syntax).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { deriveVerifyCommand } from './derive-verify-command';
+
+const SCRIPTS = {
+  test: 'vitest',
+  'test:unit': 'vitest run --exclude "**/*.integration.test.tsx"',
+  'test:integration': 'vitest run "**/*.integration.test.tsx"',
+  'test:rules': 'firebase emulators:exec --only firestore "vitest rules"',
+  lint: 'eslint .',
+  build: 'tsc -b && vite build',
+  preflight: 'pnpm lint && pnpm knip && pnpm build && pnpm test:coverage',
+  typecheck: 'tsc -b',
+};
+
+describe('deriveVerifyCommand — verbatim extraction', () => {
+  it('returns null command for null verify line', () => {
+    const r = deriveVerifyCommand(null, { scripts: SCRIPTS });
+    expect(r.command).toBeNull();
+    expect(r.source).toBe('unknown');
+  });
+
+  it('returns null command for empty verify line', () => {
+    const r = deriveVerifyCommand('   ', { scripts: SCRIPTS });
+    expect(r.command).toBeNull();
+  });
+
+  it('extracts a backtick-fenced command verbatim', () => {
+    const verify = '`pnpm run test:rules` passes new ownership assertions.';
+    const r = deriveVerifyCommand(verify, { scripts: SCRIPTS });
+    expect(r.command).toBe('pnpm run test:rules');
+    expect(r.source).toBe('verbatim');
+  });
+
+  it('prefers the first backticked pnpm command when multiple appear', () => {
+    const verify =
+      'Run `pnpm run lint` then `pnpm exec vitest run foo.test.ts`.';
+    const r = deriveVerifyCommand(verify, { scripts: SCRIPTS });
+    expect(r.command).toBe('pnpm run lint');
+  });
+
+  it('extracts a backtick-fenced `pnpm exec vitest` command', () => {
+    const verify =
+      'Run `pnpm exec vitest run scripts/harness/lib/foo.test.ts`.';
+    const r = deriveVerifyCommand(verify, { scripts: SCRIPTS });
+    expect(r.command).toBe(
+      'pnpm exec vitest run scripts/harness/lib/foo.test.ts'
+    );
+    expect(r.source).toBe('verbatim');
+  });
+});
+
+describe('deriveVerifyCommand — descriptive fallback by keyword', () => {
+  it('maps "rules" → test:rules when script exists', () => {
+    const verify = 'Firestore rules deny cross-user reads.';
+    const r = deriveVerifyCommand(verify, { scripts: SCRIPTS });
+    expect(r.command).toBe('pnpm run test:rules');
+    expect(r.source).toBe('script-match');
+  });
+
+  it('maps "lint" → lint script', () => {
+    const verify = 'No lint warnings on the new file.';
+    const r = deriveVerifyCommand(verify, { scripts: SCRIPTS });
+    expect(r.command).toBe('pnpm run lint');
+  });
+
+  it('maps "build" → preflight when present', () => {
+    const r = deriveVerifyCommand('Production build succeeds.', {
+      scripts: SCRIPTS,
+    });
+    expect(r.command).toBe('pnpm run preflight');
+  });
+
+  it('maps "tsc -b" → typecheck (typecheck rule wins over build)', () => {
+    const r = deriveVerifyCommand('tsc -b is clean.', { scripts: SCRIPTS });
+    expect(r.command).toBe('pnpm run typecheck');
+  });
+
+  it('maps "typecheck" → typecheck script when present, else preflight', () => {
+    const r1 = deriveVerifyCommand('Types compile.', { scripts: SCRIPTS });
+    expect(r1.command).toBe('pnpm run typecheck');
+    const r2 = deriveVerifyCommand('Types compile.', {
+      scripts: { ...SCRIPTS, typecheck: undefined as unknown as string },
+    });
+    // typecheck stripped → falls back to preflight
+    expect(r2.command).toBe('pnpm run preflight');
+  });
+
+  it('maps "integration" → test:integration', () => {
+    const verify = 'Integration test: store hydrates from emulator.';
+    const r = deriveVerifyCommand(verify, { scripts: SCRIPTS });
+    expect(r.command).toBe('pnpm run test:integration');
+  });
+
+  it('defaults to test:unit for unmatched descriptive verify lines', () => {
+    const verify = 'Component test: tap fires the store action.';
+    const r = deriveVerifyCommand(verify, { scripts: SCRIPTS });
+    expect(r.command).toBe('pnpm run test:unit');
+    expect(r.source).toBe('descriptive-default');
+  });
+});
+
+describe('deriveVerifyCommand — script presence validation', () => {
+  it('falls back to test when test:unit is missing', () => {
+    const r = deriveVerifyCommand('Component test passes.', {
+      scripts: { test: 'vitest', lint: 'eslint .' },
+    });
+    expect(r.command).toBe('pnpm run test');
+  });
+
+  it('returns unknown source when no test-like script exists at all', () => {
+    const r = deriveVerifyCommand('Component test passes.', {
+      scripts: { lint: 'eslint .' },
+    });
+    expect(r.source).toBe('unknown');
+    expect(r.command).toBeNull();
+  });
+
+  it('returns the verbatim command even if the script does not exist', () => {
+    // Verbatim is what the spec author asked for — we do not second-guess.
+    const r = deriveVerifyCommand('`pnpm run test:nonexistent` passes.', {
+      scripts: SCRIPTS,
+    });
+    expect(r.command).toBe('pnpm run test:nonexistent');
+    expect(r.source).toBe('verbatim');
+  });
+});
+
+describe('deriveVerifyCommand — reason field', () => {
+  it('explains verbatim extraction', () => {
+    const r = deriveVerifyCommand('`pnpm run lint` passes.', {
+      scripts: SCRIPTS,
+    });
+    expect(r.reason.toLowerCase()).toMatch(/verbatim|backtick/);
+  });
+
+  it('explains script-match derivation', () => {
+    const r = deriveVerifyCommand('Firestore rules deny.', {
+      scripts: SCRIPTS,
+    });
+    expect(r.reason).toMatch(/rules/i);
+  });
+
+  it('explains the default fallback', () => {
+    const r = deriveVerifyCommand('Component test passes.', {
+      scripts: SCRIPTS,
+    });
+    expect(r.reason.toLowerCase()).toMatch(/default|test:unit|unit/);
+  });
+});

--- a/scripts/harness/lib/derive-verify-command.ts
+++ b/scripts/harness/lib/derive-verify-command.ts
@@ -1,0 +1,127 @@
+/**
+ * Deterministic mapping from a task's `Verify:` line to a canonical pnpm
+ * command. Replaces the LLM-derivation block in builder.md (round 27 cost:
+ * $0.71 invented Jest --testPathPattern syntax on a Vitest project).
+ *
+ * Two-stage derivation:
+ *   1. If the verify line backtick-fences a `pnpm ...` command, return it
+ *      verbatim — the spec author has already chosen the canonical form.
+ *   2. Otherwise scan the verify line for keywords (rules, lint, build,
+ *      typecheck, integration, ...) and map to the closest existing script
+ *      in the project's package.json. Default: test:unit (or whichever
+ *      test-like script is present).
+ *
+ * Pure: takes the verify line + a parsed package.json scripts map, returns
+ * a plain object. The caller handles file I/O.
+ */
+
+export type DerivedVerifyCommandSource =
+  | 'verbatim'
+  | 'script-match'
+  | 'descriptive-default'
+  | 'unknown';
+
+export interface DerivedVerifyCommand {
+  /** The canonical command string, or null when no command can be derived. */
+  command: string | null;
+  source: DerivedVerifyCommandSource;
+  /** Short explanation suitable for inclusion in the builder input. */
+  reason: string;
+}
+
+export interface PackageJsonLike {
+  scripts?: Record<string, string | undefined>;
+}
+
+/** Match any backtick-fenced `pnpm ...` command. */
+const PNPM_BACKTICK_RE = /`(pnpm\s+[^`]+)`/i;
+
+/**
+ * Ordered keyword → preferred script lookup. First match wins. Each entry
+ * lists candidate script names in priority order; we return the first one
+ * present in package.json.scripts.
+ */
+const KEYWORD_RULES: Array<{ keyword: RegExp; scripts: string[] }> = [
+  { keyword: /\brules\b/i, scripts: ['test:rules'] },
+  { keyword: /\bintegration\b/i, scripts: ['test:integration'] },
+  { keyword: /\blint\b/i, scripts: ['lint'] },
+  {
+    keyword: /\btypecheck\b|\btsc\b|\btypes?\s+compile/i,
+    scripts: ['typecheck', 'preflight'],
+  },
+  { keyword: /\bbuild\b/i, scripts: ['preflight', 'build'] },
+];
+
+/** Test-like scripts to use as the default fallback, in priority order. */
+const DEFAULT_TEST_SCRIPTS = ['test:unit', 'test'];
+
+function hasScript(pkg: PackageJsonLike, name: string): boolean {
+  const scripts = pkg.scripts;
+  if (!scripts) return false;
+  return typeof scripts[name] === 'string' && scripts[name]!.length > 0;
+}
+
+function pickFirstPresent(
+  pkg: PackageJsonLike,
+  candidates: string[]
+): string | null {
+  for (const name of candidates) {
+    if (hasScript(pkg, name)) return name;
+  }
+  return null;
+}
+
+export function deriveVerifyCommand(
+  verifyLine: string | null,
+  pkg: PackageJsonLike
+): DerivedVerifyCommand {
+  if (!verifyLine || !verifyLine.trim()) {
+    return {
+      command: null,
+      source: 'unknown',
+      reason: 'verify line is empty or null',
+    };
+  }
+
+  // Stage 1: verbatim backticked pnpm command.
+  const verbatim = verifyLine.match(PNPM_BACKTICK_RE);
+  if (verbatim) {
+    const command = verbatim[1]!.trim();
+    return {
+      command,
+      source: 'verbatim',
+      reason: `extracted verbatim from backtick-fenced \`${command}\` in the verify line`,
+    };
+  }
+
+  // Stage 2: keyword → script lookup.
+  for (const rule of KEYWORD_RULES) {
+    if (rule.keyword.test(verifyLine)) {
+      const script = pickFirstPresent(pkg, rule.scripts);
+      if (script) {
+        return {
+          command: `pnpm run ${script}`,
+          source: 'script-match',
+          reason: `verify line keyword matched /${rule.keyword.source}/; package.json defines '${script}'`,
+        };
+      }
+    }
+  }
+
+  // Default: pick the best test-like script.
+  const fallback = pickFirstPresent(pkg, DEFAULT_TEST_SCRIPTS);
+  if (fallback) {
+    return {
+      command: `pnpm run ${fallback}`,
+      source: 'descriptive-default',
+      reason: `descriptive verify line; defaulted to project's '${fallback}' script`,
+    };
+  }
+
+  return {
+    command: null,
+    source: 'unknown',
+    reason:
+      'no test-like script found in package.json; cannot derive a default',
+  };
+}

--- a/scripts/harness/lib/dispatch/builder-dispatch.ts
+++ b/scripts/harness/lib/dispatch/builder-dispatch.ts
@@ -20,6 +20,7 @@ import {
   buildBuilderInput,
   formatBuilderInputMarkdown,
 } from '../builder-input';
+import { deriveVerifyCommand } from '../derive-verify-command';
 import { parseTaskList } from '../task-parser';
 import { dispatchSubagent, type DispatchResult } from '../subagent-dispatch';
 import { parseStructuredExit } from './parse-structured-exit';
@@ -126,10 +127,18 @@ export async function dispatchBuilder(
       `builder dispatch: task ${opts.taskId} not found in ${taskListPath}`
     );
   }
+  // Axis 6: derive canonical verify command from package.json + verify line
+  // so the builder doesn't reinvent flag syntax (round-27 cost: $0.71 on
+  // invented Jest --testPathPattern).
+  const derivedVerifyCommand = derivePackageJsonVerifyCommand(
+    task.verify,
+    opts.cwd
+  );
   const builderInput = buildBuilderInput({
     task,
     specMarkdown: specMd,
     designMarkdown: designMd,
+    derivedVerifyCommand,
   });
   const inputMd = formatBuilderInputMarkdown(builderInput);
 
@@ -173,4 +182,23 @@ export function parseBuilderExit(text: string): BuilderExit {
     );
   }
   return parsed as unknown as BuilderExit;
+}
+
+/**
+ * Read package.json from the dispatch cwd (or process.cwd()) and call
+ * deriveVerifyCommand. Returns null on any I/O error — derivation is a
+ * best-effort optimization, not a hard dependency.
+ */
+function derivePackageJsonVerifyCommand(
+  verifyLine: string | null,
+  cwd?: string
+): ReturnType<typeof deriveVerifyCommand> | null {
+  try {
+    const pkgPath = join(cwd ?? process.cwd(), 'package.json');
+    const raw = readFileSync(pkgPath, 'utf8');
+    const pkg = JSON.parse(raw) as { scripts?: Record<string, string> };
+    return deriveVerifyCommand(verifyLine, pkg);
+  } catch {
+    return null;
+  }
 }

--- a/scripts/harness/lib/prompts/builder.md
+++ b/scripts/harness/lib/prompts/builder.md
@@ -62,27 +62,23 @@ For every task:
    gold-plating.
 5. **Refactor.** Keep tests green.
 6. **Run the `Verify:` line literally.** It is the per-task gate.
-   - **If the verify line specifies a command verbatim** (e.g.
-     "`pnpm run test:rules` passes new assertions...") — run that
-     command exactly. Do NOT modify, augment, or substitute it.
-   - **If the verify line is descriptive** (e.g. "Component test:
-     tap fires the store action; aria-label matches the i18n value")
-     — derive the command from the project's actual test runner,
-     NOT from your own knowledge of similarly-named tools. Specifically:
-     - Read `package.json`'s `scripts` block first. Pick the closest
-       script (e.g. `test:unit`, `test`, `test:rules`).
-     - For unit tests against a single file in this project (Vitest):
-       `pnpm exec vitest run <path/to/file>`. Vitest takes positional
-       file paths, NOT Jest's `--testPathPattern` flag. Confirm by
-       checking which test framework the project's `package.json`
-       depends on (look for `vitest` vs `jest`).
-     - When in doubt, run the broadest local test command
-       (`pnpm run test:unit`) once to confirm the framework +
-       invocation pattern before constructing a narrower invocation.
-     - **Methodology basis:** round 27 hit `verify_fail` x4 because
-       the subagent invented `--testPathPattern` (Jest syntax) on a
-       Vitest project. Cost: $0.71 for a non-shipping result. This
-       rule generalizes the lesson.
+   - **If a `## Verify command (canonical, derived)` section appears in
+     your input (Axis 6 pre-derivation):** run that command exactly.
+     The harness has already mapped the verify line to a canonical pnpm
+     script in this project. Do NOT modify, augment, or substitute it.
+     If the canonical command fails for a structural reason (script
+     missing, wrong runner, infrastructure unavailable), emit `spec_gap`
+     rather than substituting your own command.
+   - **If no canonical section is present** (older harness or
+     `derived_verify_command.command` is null), fall back to deriving
+     yourself: read `package.json`'s `scripts` block, pick the closest
+     script (`test:unit`, `test:rules`, `lint`, `preflight`), and prefer
+     `pnpm exec vitest run <path>` for single-file Vitest invocations
+     (Vitest takes positional paths, NOT Jest's `--testPathPattern`).
+     **Methodology basis:** round 27 hit `verify_fail` x4 because the
+     subagent invented `--testPathPattern` (Jest syntax) on a Vitest
+     project — round 44 (Axis 6) lifted that derivation out of the
+     model into a deterministic step.
 7. **Run the verify ONE FINAL TIME** before constructing your exit
    payload. The TDD cycle in steps 3-5 includes test runs that are
    _expected_ to fail (RED → GREEN). Those iterations do NOT determine


### PR DESCRIPTION
## Summary
- New `derive-verify-command.ts`: maps a task's `Verify:` line + project `package.json` to a canonical `pnpm` command. Backtick-fenced commands extracted verbatim; otherwise keyword → script lookup (rules → test:rules, build → preflight, integration → test:integration, etc.) with default fallback to `test:unit`.
- Builder dispatcher and CLI `prepare` both invoke the derivation and inject the result under a new `## Verify command (canonical, derived)` section.
- Builder prompt step 6 trimmed: canonical command first, with descriptive-derivation fallback only for older invocations.

## Why
Axis 6 / round-27 finding: a builder dispatch hit `verify_fail` x4 ($0.71 wasted) because the subagent invented `--testPathPattern` (Jest syntax) on a Vitest project. The derivation step makes that class of error mechanically impossible.

## Test plan
- [x] 18 new unit tests in `derive-verify-command.test.ts` (verbatim, keyword fallback, script-presence validation, reason field)
- [x] 5 new tests in `builder-input.test.ts` for the canonical-section rendering
- [x] CLI snapshot regenerated; `cli-snapshots/run.test.ts` passes
- [x] Full harness suite: 349/349 green
- [x] `pnpm run preflight`: lint + knip + build + test:coverage all green
- [ ] First live builder dispatch on T-28 will validate end-to-end behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)