### PR TITLE
fix(harness): dispatches.jsonl path double-prefix bug (finding #15)

### DIFF
--- a/scripts/harness/lib/state-store.test.ts
+++ b/scripts/harness/lib/state-store.test.ts
@@ -114,6 +114,35 @@ describe('state-store', () => {
     ]);
   });
 
+  it('writes dispatches.jsonl as a sibling of state.json (finding #15 regression guard)', () => {
+    initState('T-28', statePath);
+    appendEvent(statePath, {
+      task_id: 'T-28',
+      type: 'dispatch_end',
+      payload: {
+        role: 'builder',
+        cost_usd: 0.5,
+        duration_ms: 1000,
+        num_turns: 5,
+        session_id: 'sess-1',
+        stop_reason: 'end_turn',
+        status: 'success',
+      },
+    });
+    const expectedJsonl = join(workDir, '.harness/dispatches.jsonl');
+    const buggyDoubleNested = join(
+      workDir,
+      '.harness/.harness/dispatches.jsonl'
+    );
+    expect(existsSync(expectedJsonl)).toBe(true);
+    expect(existsSync(buggyDoubleNested)).toBe(false);
+    const lines = readFileSync(expectedJsonl, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.task_id).toBe('T-28');
+    expect(parsed.role).toBe('builder');
+  });
+
   // Cleanup helper
   it('cleanup', () => {
     rmSync(workDir, { recursive: true, force: true });

--- a/scripts/harness/lib/state-store.ts
+++ b/scripts/harness/lib/state-store.ts
@@ -18,11 +18,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import {
-  appendDispatch,
-  defaultDispatchesLogPath,
-  type DispatchLogEntry,
-} from './dispatches-log';
+import { appendDispatch, type DispatchLogEntry } from './dispatches-log';
 
 export type StateEventType =
   | 'orchestrate_start'
@@ -103,8 +99,12 @@ export function appendEvent(
   // never overwritten — survives across orchestrate runs and across tasks.
   if (event.type === 'dispatch_end' || event.type === 'pushback_dispatch') {
     if (opts.dispatchesLogPath !== null) {
+      // Sibling of state.json — `dirname(path)` is the .harness/ directory
+      // already; do NOT pass it to defaultDispatchesLogPath (which prepends
+      // its own `.harness/`, producing the round-45 finding-#15 bug:
+      // `.harness/.harness/dispatches.jsonl`).
       const logPath =
-        opts.dispatchesLogPath ?? defaultDispatchesLogPath(dirname(path));
+        opts.dispatchesLogPath ?? resolve(dirname(path), 'dispatches.jsonl');
       const entry = buildDispatchLogEntry(
         state.run_id,
         event.task_id,


### PR DESCRIPTION
## Summary
`state-store.appendEvent` was writing to `.harness/.harness/dispatches.jsonl` instead of `.harness/dispatches.jsonl`. The dual-write WAS happening — `harness stats` just couldn't find the file because it looks at the canonical path.

## Root cause
```ts
const logPath = opts.dispatchesLogPath ?? defaultDispatchesLogPath(dirname(path));
```

- `path` = `<cwd>/.harness/state.json` (absolute, via `defaultStatePath`)
- `dirname(path)` = `<cwd>/.harness/`
- `defaultDispatchesLogPath(cwd)` = `resolve(cwd, '.harness/dispatches.jsonl')`
- Result: `<cwd>/.harness/.harness/dispatches.jsonl`

## Fix
Compute jsonl as a sibling of state.json directly, no helper round-trip:
```ts
const logPath = opts.dispatchesLogPath ?? resolve(dirname(path), 'dispatches.jsonl');
```

Drops the now-unused `defaultDispatchesLogPath` import from state-store. The CLI's separate use of `defaultDispatchesLogPath()` (no args, cwd-default) still resolves to the same canonical path.

## Surfaced by
T-28 dispatch in PR #207 (round 45). State.json captured everything correctly; `harness stats` returned "no dispatches logged" because it was looking at the wrong (correct) path.

## Test plan
- [x] New regression-guard test in `state-store.test.ts` asserts the jsonl exists at `.harness/dispatches.jsonl` AND does NOT exist at `.harness/.harness/dispatches.jsonl`
- [x] Full harness suite: 350/350 green
- [x] `pnpm run preflight`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)